### PR TITLE
REDCap Util fixes and Kafka Source Reader extensions

### DIFF
--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/KafkaSourceReader.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/KafkaSourceReader.scala
@@ -1,11 +1,17 @@
 package io.tofhir.engine.data.read
 
 import io.tofhir.engine.model.{KafkaSource, KafkaSourceSettings}
-import org.apache.spark.sql.functions.from_json
-import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.sql.functions.{col, from_json, udf}
+import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, LongType, StringType, StructType}
 import org.apache.spark.sql.{DataFrame, SparkSession}
-
 import java.time.LocalDateTime
+
+import com.fasterxml.jackson.core.JsonParseException
+import io.onfhir.api.Resource
+import io.onfhir.util.JsonFormatter._
+import javax.ws.rs.InternalServerErrorException
+import org.json4s.{JBool, JLong, JNull}
+import org.json4s.JsonAST.{JDouble, JInt}
 
 /**
  *
@@ -27,6 +33,55 @@ class KafkaSourceReader(spark: SparkSession) extends BaseDataSourceReader[KafkaS
       throw new IllegalArgumentException("Schema is required for streaming source")
     }
 
+    // user-defined function (UDF) to process message (json) coming from the Kafka topic
+    val processDataUDF = udf((message:String) => {
+      var json:Resource = null
+      // try-catch block needed to handle unparseable json
+      try {
+        json = message.parseJson
+      }
+      catch {
+        case e:JsonParseException =>  throw new InternalServerErrorException("Kafka message is an unparseable json",e)
+      }
+      // process each field so that string values are acceptable (if they are parseable of course) for some data types such as double and integer
+      json.mapField(field => {
+        // get field type from the schema
+        val fieldType = schema.get.fields.find(p => p.name.contentEquals(field._1)).orNull
+        if(fieldType == null){
+          // the data contains a field which does not exist in the schema, no need to process it
+          field
+        } else {
+          fieldType.dataType match {
+            case _:DoubleType =>
+              try {
+                (field._1, if(field._2.extract[String].isEmpty) JNull else JDouble(field._2.extract[String].toDouble))
+              } catch {
+                case e: NumberFormatException => throw new InternalServerErrorException(s"${field._2} is not a parsable `Double`",e)
+              }
+            case _:IntegerType =>
+              try {
+                (field._1, if(field._2.extract[String].isEmpty) JNull else JInt(field._2.extract[String].toInt))
+              } catch {
+                case e: NumberFormatException => throw new InternalServerErrorException(s"${field._2} is not a parsable `Integer`",e)
+              }
+            case _:LongType =>
+              try {
+                (field._1, if(field._2.extract[String].isEmpty) JNull else JLong(field._2.extract[String].toLong))
+              } catch {
+                case e: NumberFormatException => throw new InternalServerErrorException(s"${field._2} is not a parsable `Long`",e)
+              }
+            case _:BooleanType =>
+              try {
+                (field._1, if(field._2.extract[String].isEmpty) JNull else JBool(field._2.extract[String].toBoolean))
+              } catch {
+                case e: IllegalArgumentException => throw new InternalServerErrorException(s"${field._2} is not a parsable `Boolean`",e)
+              }
+            case _ => field
+          }
+        }
+      }).toJson
+    })
+
     val df = spark
       .readStream
       .format("kafka")
@@ -35,7 +90,9 @@ class KafkaSourceReader(spark: SparkSession) extends BaseDataSourceReader[KafkaS
       .option("startingOffsets", mappingSource.startingOffsets)
       .option("inferSchema", true)
       .load()
-      .select(from_json($"value".cast(StringType), schema.get).as("record"))
+      .select($"value".cast(StringType)) // change the type of message from binary to string
+      .withColumn("value",processDataUDF(col("value"))) // replace 'value' column with the processed data
+      .select(from_json($"value", schema.get).as("record"))
       .select("record.*")
     df
 

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/util/RedCapUtil.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/util/RedCapUtil.scala
@@ -24,7 +24,8 @@ object RedCapUtil {
       val schemaName = form._1
       val schemaId = schemaName.capitalize
       // get schema definitions
-      val definitions = form._2.map(row => {
+      var definitions:Seq[SimpleStructureDefinition] = Seq.empty
+      form._2.foreach(row => {
         // read columns
         val variableName = row(RedCapDataDictionaryColumns.VARIABLE_FIELD_NAME)
         val fieldType = row(RedCapDataDictionaryColumns.FIELD_TYPE)
@@ -33,33 +34,37 @@ object RedCapUtil {
         val required = row(RedCapDataDictionaryColumns.REQUIRED_FIELD)
         val textValidationType = row.get(RedCapDataDictionaryColumns.TEXT_VALIDATION_TYPE)
 
-        // find applicable data type
-        val dataType = getDataType(fieldType, textValidationType)
-        // find cardinality
-        val cardinality = getCardinality(fieldType, required)
+        // discard the descriptive fields since they do not provide any data and they are not included in the export
+        // record response
+        if(!fieldType.contentEquals(RedCapDataTypes.DESCRIPTIVE)){
+          // find applicable data type
+          val dataType = getDataType(fieldType, textValidationType)
+          // find cardinality
+          val cardinality = getCardinality(fieldType, required)
 
-        SimpleStructureDefinition(id = variableName,
-          path = s"${schemaId}.${variableName}",
-          dataTypes = Some(Seq(dataType)),
-          isPrimitive = false,
-          isChoiceRoot = false,
-          isArray = cardinality._2.isEmpty,
-          minCardinality = cardinality._1,
-          maxCardinality = cardinality._2,
-          boundToValueSet = None,
-          isValueSetBindingRequired = None,
-          referencableProfiles = None,
-          constraintDefinitions = None,
-          sliceDefinition = None,
-          sliceName = None,
-          fixedValue = None,
-          patternValue = None,
-          referringTo = None,
-          short = Some(fieldLabel),
-          definition = Some(fieldNotes),
-          comment = None,
-          elements = None
-        )
+          definitions = definitions :+ SimpleStructureDefinition(id = variableName,
+            path = s"$schemaId.$variableName",
+            dataTypes = Some(Seq(dataType)),
+            isPrimitive = false,
+            isChoiceRoot = false,
+            isArray = cardinality._2.isEmpty,
+            minCardinality = cardinality._1,
+            maxCardinality = cardinality._2,
+            boundToValueSet = None,
+            isValueSetBindingRequired = None,
+            referencableProfiles = None,
+            constraintDefinitions = None,
+            sliceDefinition = None,
+            sliceName = None,
+            fixedValue = None,
+            patternValue = None,
+            referringTo = None,
+            short = Some(fieldLabel),
+            definition = Some(fieldNotes),
+            comment = None,
+            elements = None
+          )
+        }
       })
       val definition = SchemaDefinition(id = schemaId,
         url = s"$definitionRootUrl/${FHIR_FOUNDATION_RESOURCES.FHIR_STRUCTURE_DEFINITION}/$schemaId",

--- a/tofhir-engine/src/test/resources/test-mappings/some-folder-1/family-member-history-mapping.json
+++ b/tofhir-engine/src/test/resources/test-mappings/some-folder-1/family-member-history-mapping.json
@@ -1,0 +1,42 @@
+{
+	"id": "family-member-history-mapping",
+	"url": "https://aiccelerate.eu/fhir/mappings/family-member-history-mapping",
+	"name": "family-member-history-mapping",
+	"title": "Mapping of family member history schema for pilots to FamilyMemberHistory FHIR profile",
+	"source": [
+		{
+			"alias": "source",
+			"url": "https://aiccelerate.eu/fhir/StructureDefinition/Ext-family-member-history"
+		}
+	],
+	"mapping": [
+		{
+			"expression": {
+				"name": "result",
+				"language": "application/fhir-template+json",
+				"value": {
+					"resourceType": "FamilyMemberHistory",
+					"id": "{{mpp:getHashedId('FamilyMemberHistory',name)}}",
+					"meta": {
+						"profile": [
+							"http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory"
+						],
+						"source": "{{%sourceSystem.sourceUri}}"
+					},
+					"status": "completed",
+					"patient": "{{mpp:createFhirReferenceWithHashedId('Patient', name)}}",
+					"relationship": {
+						"coding": [
+							{
+								"code": "82101005",
+								"system": "http://snomed.info/sct"
+							}
+						]
+					},
+					"deceasedBoolean": "{{deceased}}",
+					"bornDate": "{{birthDate_y.toString()}}-{{iif(birthDate_m.toString().length() = 2, birthDate_m.toString(), '0' & birthDate_m.toString())}}-{{iif(birthDate_d.toString().length() = 2, birthDate_d.toString(), '0' & birthDate_d.toString())}}"
+				}
+			}
+		}
+	]
+}

--- a/tofhir-engine/src/test/resources/test-schemas/some-folder-1/Ext-family-member-history.StructureDefinition.json
+++ b/tofhir-engine/src/test/resources/test-schemas/some-folder-1/Ext-family-member-history.StructureDefinition.json
@@ -1,0 +1,107 @@
+{
+	"resourceType": "StructureDefinition",
+	"url": "https://aiccelerate.eu/fhir/StructureDefinition/Ext-family-member-history",
+	"name": "ext-family-member-history",
+	"status": "draft",
+	"fhirVersion": "4.0.1",
+	"kind": "logical",
+	"abstract": false,
+	"type": "Ext-family-member-history",
+	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Element",
+	"derivation": "specialization",
+	"differential": {
+		"element": [
+			{
+				"id": "Ext-family-member-history",
+				"path": "Ext-family-member-history",
+				"min": 0,
+				"max": "*",
+				"type": [
+					{
+						"code": "Element"
+					}
+				]
+			},
+			{
+				"id": "Ext-family-member-history.name",
+				"path": "Ext-family-member-history.name",
+				"short": "Name",
+				"definition": "Name",
+				"min": 1,
+				"max": "1",
+				"type": [
+					{
+						"code": "string",
+						"profile": [
+							"http://hl7.org/fhir/StructureDefinition/string"
+						]
+					}
+				]
+			},
+			{
+				"id": "Ext-family-member-history.deceased",
+				"path": "Ext-family-member-history.deceased",
+				"short": "Dead",
+				"definition": "Dead",
+				"min": 1,
+				"max": "1",
+				"type": [
+					{
+						"code": "boolean",
+						"profile": [
+							"http://hl7.org/fhir/StructureDefinition/boolean"
+						]
+					}
+				]
+			},
+			{
+				"id": "Ext-family-member-history.birthDate_y",
+				"path": "Ext-family-member-history.birthDate_y",
+				"short": "Year",
+				"definition": "Year",
+				"min": 0,
+				"max": "1",
+				"type": [
+					{
+						"code": "integer",
+						"profile": [
+							"http://hl7.org/fhir/StructureDefinition/integer"
+						]
+					}
+				]
+			},
+			{
+				"id": "Ext-family-member-history.birthDate_m",
+				"path": "Ext-family-member-history.birthDate_m",
+				"short": "Month",
+				"definition": "Month",
+				"min": 0,
+				"max": "1",
+				"type": [
+					{
+						"code": "integer",
+						"profile": [
+							"http://hl7.org/fhir/StructureDefinition/integer"
+						]
+					}
+				]
+			},
+			{
+				"id": "Ext-family-member-history.birthDate_d",
+				"path": "Ext-family-member-history.birthDate_d",
+				"short": "Day",
+				"definition": "Day",
+				"min": 0,
+				"max": "1",
+				"type": [
+					{
+						"code": "integer",
+						"profile": [
+							"http://hl7.org/fhir/StructureDefinition/integer"
+						]
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
This MR includes the following changes:

- Fix REDCap util to handle descriptive fields
- Extend KafkaSourceReader to accept string values for double, integer, long and boolean data types
- Modify KafkaSourceReader so that it throws an exception when it encounters a corrupted message (i.e. invalid json)
- Add tests for KafkaSourceReader changes