### PR TITLE
Fix tests and mapping cache

### DIFF
--- a/tofhir-engine/src/main/scala/io/tofhir/engine/ToFhirEngine.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/ToFhirEngine.scala
@@ -1,6 +1,6 @@
 package io.tofhir.engine
 
-import io.onfhir.path.{FhirPathNavFunctionsFactory, FhirPathUtilFunctionsFactory, IFhirPathFunctionLibraryFactory}
+import io.onfhir.path.{FhirPathNavFunctionsFactory, FhirPathUtilFunctionsFactory, FhirPathAggFunctionsFactory, FhirPathTerminologyServiceFunctionsFactory, FhirPathIdentityServiceFunctionsFactory, IFhirPathFunctionLibraryFactory}
 import io.tofhir.engine.config.{ToFhirConfig, ToFhirEngineConfig}
 import io.tofhir.engine.mapping._
 import io.tofhir.engine.model.EngineInitializationException
@@ -50,7 +50,10 @@ class ToFhirEngine(mappingRepository: Option[IFhirMappingCachedRepository] = Non
   private def initializeFunctionLibraries(): Map[String, IFhirPathFunctionLibraryFactory] = {
     Map(
       FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory,
-      FhirPathNavFunctionsFactory.defaultPrefix -> FhirPathNavFunctionsFactory
+      FhirPathNavFunctionsFactory.defaultPrefix -> FhirPathNavFunctionsFactory,
+      FhirPathAggFunctionsFactory.defaultPrefix -> FhirPathAggFunctionsFactory,
+      FhirPathIdentityServiceFunctionsFactory.defaultPrefix -> FhirPathIdentityServiceFunctionsFactory,
+      FhirPathTerminologyServiceFunctionsFactory.defaultPrefix -> FhirPathTerminologyServiceFunctionsFactory
     ) ++ functionLibraryFactories
   }
 }

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/mapping/MappingContextLoader.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/mapping/MappingContextLoader.scala
@@ -44,14 +44,23 @@ class MappingContextLoader(fhirMappingRepository: IFhirMappingRepository) extend
   }
 
   /**
-   * Read the CSV file from the given filePath and return a Sequence where each element is a Map[column_name -> value)
+   * Read the CSV file from the given filePath and return a Sequence where each element is a Map[column_name -> value).
+   * It handles {@link FhirMappingContextUrlPlaceHolder.CONTEXT_REPO} placeholder in the given filePath by replacing it
+   * with the mapping context repository folder path.
    *
    * @param filePath
    * @return
    */
   private def readFromCSV(filePath: String): Future[(Seq[String],Seq[Map[String, String]])] = {
+    val path =
+    // replace $CONTEXT_REPO placeholder
+    if (filePath.contains(FhirMappingContextUrlPlaceHolder.CONTEXT_REPO))
+      filePath.replace(FhirMappingContextUrlPlaceHolder.CONTEXT_REPO,
+        ToFhirConfig.engineConfig.mappingContextRepositoryFolderPath)
+     else
+      filePath
     Future {
-      CsvUtil.readFromCSVAndReturnWithColumnNames(filePath)
+      CsvUtil.readFromCSVAndReturnWithColumnNames(path)
     }
   }
 

--- a/tofhir-engine/src/test/scala/io/tofhir/integrationtest/KafkaSourceIntegrationTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/integrationtest/KafkaSourceIntegrationTest.scala
@@ -25,6 +25,7 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.{Collections, Properties, UUID}
 
+import io.onfhir.path.FhirPathUtilFunctionsFactory
 import scala.concurrent.Await
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
@@ -101,7 +102,7 @@ class KafkaSourceIntegrationTest extends AnyFlatSpec with ToFhirTestSpec with Be
     Try(Await.result(onFhirClient.search("Patient").execute(), FiniteDuration(5, TimeUnit.SECONDS)).httpStatus == StatusCodes.OK)
       .getOrElse(false)
 
-  val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, ErrorHandlingType.HALT)
+  val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map(FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory), sparkSession, ErrorHandlingType.HALT)
 
   it should "check the test container working" in {
     val topicName = "testTopic"

--- a/tofhir-engine/src/test/scala/io/tofhir/test/FhirMappingJobManagerTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/FhirMappingJobManagerTest.scala
@@ -18,6 +18,7 @@ import java.io.File
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import io.onfhir.path.FhirPathUtilFunctionsFactory
+import io.onfhir.path.FhirPathIdentityServiceFunctionsFactory
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext}
 import scala.util.Try
@@ -188,7 +189,7 @@ class FhirMappingJobManagerTest extends AsyncFlatSpec with BeforeAndAfterAll wit
   }
 
   it should "execute the other observation mapping task and return the results" in {
-    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map("utl" -> FhirPathUtilFunctionsFactory), sparkSession, mappingErrorHandling)
+    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map(FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory), sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(otherObservationMappingTask)) , sourceSettings = dataSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
         r.mappedResource shouldBe defined
@@ -221,7 +222,7 @@ class FhirMappingJobManagerTest extends AsyncFlatSpec with BeforeAndAfterAll wit
   it should "execute the mapping job with multiple mapping tasks and write the results into a FHIR repository" in {
     assume(fhirServerIsAvailable)
 
-    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, mappingErrorHandling)
+    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map(FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory), sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingJob(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(patientMappingTask, otherObservationMappingTask)), sourceSettings = dataSourceSettings, sinkSettings = fhirSinkSettings) flatMap { response =>
       onFhirClient.read("Patient", FhirMappingUtility.getHashedId("Patient", "p8")).executeAndReturnResource() flatMap { p1Resource =>
         FHIRUtil.extractIdFromResource(p1Resource) shouldBe FhirMappingUtility.getHashedId("Patient", "p8")
@@ -297,7 +298,8 @@ class FhirMappingJobManagerTest extends AsyncFlatSpec with BeforeAndAfterAll wit
     val terminologyServiceFolderPath = Paths.get(getClass.getResource("/terminology-service").toURI).normalize().toAbsolutePath.toString
     val terminologyServiceSettings = LocalFhirTerminologyServiceSettings(terminologyServiceFolderPath)
 
-    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, new MappingContextLoader(mappingRepository), schemaRepository, Map.empty, sparkSession, lMappingJob.mappingErrorHandling)
+    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, new MappingContextLoader(mappingRepository), schemaRepository, Map(FhirPathIdentityServiceFunctionsFactory.defaultPrefix -> FhirPathIdentityServiceFunctionsFactory,
+      FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory), sparkSession, lMappingJob.mappingErrorHandling)
     fhirMappingJobManager
       .executeMappingJob(
         mappingJobExecution = FhirMappingJobExecution(mappingTasks = lMappingJob.mappings),

--- a/tofhir-engine/src/test/scala/io/tofhir/test/FhirMappingJobManagerTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/FhirMappingJobManagerTest.scala
@@ -17,6 +17,7 @@ import org.scalatest.{Assertion, BeforeAndAfterAll}
 import java.io.File
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
+import io.onfhir.path.FhirPathUtilFunctionsFactory
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext}
 import scala.util.Try
@@ -187,7 +188,7 @@ class FhirMappingJobManagerTest extends AsyncFlatSpec with BeforeAndAfterAll wit
   }
 
   it should "execute the other observation mapping task and return the results" in {
-    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, mappingErrorHandling)
+    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map("utl" -> FhirPathUtilFunctionsFactory), sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(otherObservationMappingTask)) , sourceSettings = dataSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
         r.mappedResource shouldBe defined

--- a/tofhir-engine/src/test/scala/io/tofhir/test/FhirMappingJobManagerTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/FhirMappingJobManagerTest.scala
@@ -119,7 +119,7 @@ class FhirMappingJobManagerTest extends AsyncFlatSpec with BeforeAndAfterAll wit
     val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(patientMappingTask)) , sourceSettings = dataSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
-        r.mappedResource shouldBe defined
+        r.mappedResource should not be None
         val resource = r.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource
@@ -192,7 +192,7 @@ class FhirMappingJobManagerTest extends AsyncFlatSpec with BeforeAndAfterAll wit
     val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map(FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory), sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(otherObservationMappingTask)) , sourceSettings = dataSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
-        r.mappedResource shouldBe defined
+        r.mappedResource should not be None
         val resource = r.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource
@@ -279,7 +279,7 @@ class FhirMappingJobManagerTest extends AsyncFlatSpec with BeforeAndAfterAll wit
 
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(jobId = "test-task-with-terminology-service",mappingTasks = Seq(mappingTask)), dataSourceSettings, Some(terminologyServiceSettings)) flatMap { result =>
       val resources = result.map(mappingResult => {
-        mappingResult.mappedResource shouldBe defined
+        mappingResult.mappedResource should not be None
         val resource = mappingResult.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource
@@ -315,7 +315,7 @@ class FhirMappingJobManagerTest extends AsyncFlatSpec with BeforeAndAfterAll wit
     val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(patientMappingTaskWithPreprocess)), sourceSettings = dataSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
-        r.mappedResource shouldBe defined
+        r.mappedResource should not be None
         val resource = r.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource

--- a/tofhir-engine/src/test/scala/io/tofhir/test/SchedulingTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/SchedulingTest.scala
@@ -20,6 +20,7 @@ import java.nio.file.{Path, Paths}
 import java.sql.{Connection, DriverManager, Statement}
 import java.util.concurrent.TimeUnit
 
+import io.onfhir.path.FhirPathUtilFunctionsFactory
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.io.{BufferedSource, Source}
@@ -99,7 +100,7 @@ class SchedulingTest extends AnyFlatSpec with BeforeAndAfterAll with ToFhirTestS
     assume(fhirServerIsAvailable)
     val lMappingJob: FhirMappingJob = FhirMappingJobFormatter.readMappingJobFromFile(testScheduleMappingJobFilePath)
 
-    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, new MappingContextLoader(mappingRepository), schemaRepository, Map.empty, sparkSession, lMappingJob.mappingErrorHandling, Some(mappingJobScheduler))
+    val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, new MappingContextLoader(mappingRepository), schemaRepository, Map(FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory), sparkSession, lMappingJob.mappingErrorHandling, Some(mappingJobScheduler))
     fhirMappingJobManager.scheduleMappingJob(mappingJobExecution = FhirMappingJobExecution(mappingTasks = lMappingJob.mappings), sourceSettings = lMappingJob.sourceSettings, sinkSettings = lMappingJob.sinkSettings, schedulingSettings = lMappingJob.schedulingSettings.get)
     scheduler.start() //job set to run every minute
     Thread.sleep(61000) //wait for the job to be executed once

--- a/tofhir-engine/src/test/scala/io/tofhir/test/SqlSourceTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/SqlSourceTest.scala
@@ -108,7 +108,7 @@ class SqlSourceTest extends AsyncFlatSpec with BeforeAndAfterAll with ToFhirTest
   "Patient mapping" should "should read data from SQL source and map it" in {
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(patientMappingTask)) , sourceSettings = sqlSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
-        r.mappedResource shouldBe defined
+        r.mappedResource should not be None
         val resource = r.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource
@@ -142,7 +142,7 @@ class SqlSourceTest extends AsyncFlatSpec with BeforeAndAfterAll with ToFhirTest
   "Other observations mapping" should "should read data from SQL source and map it" in {
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(otherObsMappingTask)), sourceSettings = sqlSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
-        r.mappedResource shouldBe defined
+        r.mappedResource should not be None
         val resource = r.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource
@@ -184,7 +184,7 @@ class SqlSourceTest extends AsyncFlatSpec with BeforeAndAfterAll with ToFhirTest
     val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(careSiteMappingTask)) , sourceSettings = sqlSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
-        r.mappedResource shouldBe defined
+        r.mappedResource should not be None
         val resource = r.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource
@@ -219,7 +219,7 @@ class SqlSourceTest extends AsyncFlatSpec with BeforeAndAfterAll with ToFhirTest
     val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(locationMappingTask)) , sourceSettings = sqlSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
-        r.mappedResource shouldBe defined
+        r.mappedResource should not be None
         val resource = r.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource
@@ -252,7 +252,7 @@ class SqlSourceTest extends AsyncFlatSpec with BeforeAndAfterAll with ToFhirTest
     val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, mappingErrorHandling)
     fhirMappingJobManager.executeMappingTaskAndReturn(mappingJobExecution = FhirMappingJobExecution(mappingTasks = Seq(procedureOccurrenceMappingTask)) , sourceSettings = sqlSourceSettings) map { mappingResults =>
       val results = mappingResults.map(r => {
-        r.mappedResource shouldBe defined
+        r.mappedResource should not be None
         val resource = r.mappedResource.get.parseJson
         resource shouldBe a[Resource]
         resource

--- a/tofhir-engine/src/test/scala/io/tofhir/test/SqlSourceTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/SqlSourceTest.scala
@@ -17,6 +17,7 @@ import org.scalatest.flatspec.AsyncFlatSpec
 
 import java.sql.{Connection, DriverManager, Statement}
 import java.util.concurrent.TimeUnit
+import io.onfhir.path.FhirPathUtilFunctionsFactory
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.io.{BufferedSource, Source}
@@ -66,7 +67,7 @@ class SqlSourceTest extends AsyncFlatSpec with BeforeAndAfterAll with ToFhirTest
         SqlSourceSettings(name = "test-db-source", sourceUri = "https://aiccelerate.eu/data-integration-suite/test-data", databaseUrl = DATABASE_URL, username = "", password = "")
     )
 
-  val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map.empty, sparkSession, mappingErrorHandling)
+  val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map("utl" -> FhirPathUtilFunctionsFactory), sparkSession, mappingErrorHandling)
 
   val fhirSinkSetting: FhirRepositorySinkSettings = FhirRepositorySinkSettings(fhirRepoUrl = "http://localhost:8081/fhir", errorHandling = Some(fhirWriteErrorHandling))
   val onFhirClient: OnFhirNetworkClient = OnFhirNetworkClient.apply(fhirSinkSetting.fhirRepoUrl)

--- a/tofhir-engine/src/test/scala/io/tofhir/test/SqlSourceTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/SqlSourceTest.scala
@@ -67,7 +67,7 @@ class SqlSourceTest extends AsyncFlatSpec with BeforeAndAfterAll with ToFhirTest
         SqlSourceSettings(name = "test-db-source", sourceUri = "https://aiccelerate.eu/data-integration-suite/test-data", databaseUrl = DATABASE_URL, username = "", password = "")
     )
 
-  val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map("utl" -> FhirPathUtilFunctionsFactory), sparkSession, mappingErrorHandling)
+  val fhirMappingJobManager = new FhirMappingJobManager(mappingRepository, contextLoader, schemaRepository, Map(FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory), sparkSession, mappingErrorHandling)
 
   val fhirSinkSetting: FhirRepositorySinkSettings = FhirRepositorySinkSettings(fhirRepoUrl = "http://localhost:8081/fhir", errorHandling = Some(fhirWriteErrorHandling))
   val onFhirClient: OnFhirNetworkClient = OnFhirNetworkClient.apply(fhirSinkSetting.fhirRepoUrl)

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
@@ -2,7 +2,6 @@ package io.tofhir.server.service.mapping
 
 import io.onfhir.util.JsonFormatter._
 import io.tofhir.engine.Execution.actorSystem.dispatcher
-import io.tofhir.engine.mapping.{FhirMappingFolderRepository, MappingContextLoader}
 import io.tofhir.engine.model.FhirMapping
 import io.tofhir.engine.util.FileUtils
 import io.tofhir.engine.util.FileUtils.FileExtensions
@@ -24,7 +23,7 @@ import scala.io.Source
  * @param mappingRepositoryFolderPath root folder path to the mapping repository
  * @param projectFolderRepository     project repository to update corresponding projects based on updates on the mappings
  */
-class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projectFolderRepository: ProjectFolderRepository) extends FhirMappingFolderRepository(FileUtils.getPath(mappingRepositoryFolderPath).toUri) with IMappingRepository {
+class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projectFolderRepository: ProjectFolderRepository) extends IMappingRepository {
   // project id -> mapping id -> mapping
   private val mappingDefinitions: mutable.Map[String, mutable.Map[String, FhirMapping]] = initMap(mappingRepositoryFolderPath)
 

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
@@ -11,8 +11,11 @@ import io.tofhir.server.service.project.ProjectFolderRepository
 import org.json4s.jackson.Serialization.writePretty
 
 import java.io.{File, FileWriter}
+import java.nio.charset.StandardCharsets
+import io.onfhir.api.util.IOUtil
 import scala.collection.mutable
 import scala.concurrent.Future
+import scala.io.Source
 
 /**
  * Folder/Directory based mapping repository implementation. This implementation manages [[FhirMapping]]s per project.
@@ -65,14 +68,11 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
       fw.write(writePretty(mapping))
       fw.close()
 
-      // Normalize the concept map uris so that they could be resolved during the mapping execution
-      val mappingWithNormalizedConceptMapUris: FhirMapping = MappingContextLoader.normalizeContextURLs(Seq(mapping -> newFile)).head
-
       // Add to the project metadata json file
-      projectFolderRepository.addMapping(projectId, mappingWithNormalizedConceptMapUris)
+      projectFolderRepository.addMapping(projectId, mapping)
       // Add to the in-memory map
-      mappingDefinitions.getOrElseUpdate(projectId, mutable.Map.empty).put(mapping.id, mappingWithNormalizedConceptMapUris)
-      mappingWithNormalizedConceptMapUris
+      mappingDefinitions.getOrElseUpdate(projectId, mutable.Map.empty).put(mapping.id, mapping)
+      mapping
     })
   }
 
@@ -110,15 +110,11 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
       val fw = new FileWriter(file)
       fw.write(writePretty(mapping))
       fw.close()
-
-      // Normalize the concept map uris so that they could be resolved during the mapping execution
-      val mappingWithNormalizedConceptMapUris: FhirMapping = MappingContextLoader.normalizeContextURLs(Seq(mapping -> file)).head
-
       // update the mapping in the in-memory map
-      mappingDefinitions(projectId).put(id, mappingWithNormalizedConceptMapUris)
+      mappingDefinitions(projectId).put(id, mapping)
       // update the projects metadata json file
-      projectFolderRepository.updateMapping(projectId, mappingWithNormalizedConceptMapUris)
-      mappingWithNormalizedConceptMapUris
+      projectFolderRepository.updateMapping(projectId, mapping)
+      mapping
     })
   }
 
@@ -185,11 +181,15 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
     var directories = Seq.empty[File]
     directories = folder.listFiles.filter(_.isDirectory).toSeq
     directories.foreach { projectDirectory =>
-      // Load the mappings in the project directory
-      val fhirMappingMap: mutable.Map[String, FhirMapping] = mutable.Map[String, FhirMapping](
-        loadMappings(projectDirectory.toURI) // Load mappings as (url, mapping) pairs
-          .map(entry => entry._2.id -> entry._2).toSeq: _* // Transform mapping entries to (id, mapping) pairs
-      )
+      // mapping-id -> FhirMapping
+      val fhirMappingMap: mutable.Map[String, FhirMapping] = mutable.Map.empty
+      val files = IOUtil.getFilesFromFolder(projectDirectory, withExtension = Some(FileExtensions.JSON.toString), recursively = Some(true))
+      files.foreach { file =>
+        val source = Source.fromFile(file, StandardCharsets.UTF_8.name()) // read the JSON file
+        val fileContent = try source.mkString finally source.close()
+        val fhirMapping = fileContent.parseJson.extract[FhirMapping]
+        fhirMappingMap.put(fhirMapping.id, fhirMapping)
+      }
       map.put(projectDirectory.getName, fhirMappingMap)
     }
     map


### PR DESCRIPTION
This MR aims to fix following problems:

- Some test cases fail because FhirPath function libraries are not provided to FhirMappingJobManager.
- Mapping cache stores the mappings with normalized context urls which breaks the UI.