### PR TITLE
Fix SchemaUtil to handle optional element description

### DIFF
--- a/tofhir-common/src/main/scala/io/tofhir/common/util/SchemaUtil.scala
+++ b/tofhir-common/src/main/scala/io/tofhir/common/util/SchemaUtil.scala
@@ -59,16 +59,22 @@ object SchemaUtil {
         case Some(v) => v.toString
         case None => "*"
       }
-      ("id" -> fd.path) ~
-        ("path" -> fd.path) ~
-        ("short" -> fd.short) ~
-        ("definition" -> fd.definition) ~
-        ("min" -> fd.minCardinality) ~
-        ("max" -> max) ~
-        ("type" -> fd.dataTypes.get.map { dt =>
-          ("code" -> dt.dataType) ~
-            ("profile" -> dt.profiles)
-        })
+      // create element json
+      var elementJson =
+        ("id" -> fd.path) ~
+          ("path" -> fd.path) ~
+          ("short" -> fd.short) ~
+          ("min" -> fd.minCardinality) ~
+          ("max" -> max) ~
+          ("type" -> fd.dataTypes.get.map { dt =>
+            ("code" -> dt.dataType) ~
+              ("profile" -> dt.profiles)
+          })
+      // add the field definition if it exists
+      if(fd.definition.nonEmpty){
+        elementJson = elementJson ~ ("definition" -> fd.definition)
+      }
+      elementJson
     }.toList
 
     JArray(rootElement +: elements)


### PR DESCRIPTION
Although element definition field is optional, we can not create a schema having an element with no description. 

I have fixed SchemaUtil so that it does not add a description field in the resource if element has no description. Moreover, I've added a test case.