### PR TITLE
Extend CSV reader with file encoding argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If no arguments are provided, toFHIR starts the command line interface (CLI). Po
 - `extract-redcap-schemas`: Extracts schemas from a REDCap data dictionary. `extract-redcap-schemas` command accepts the following parameters:
   - `--data-dictionary`: The path to the REDCap data dictionary
   - `--definition-root-url`: The root url of FHIR resources
+  - `--encoding`: The encoding of CSV file whose default value is UTF-8 (OPTIONAL)
 ## CLI
 
 toFHIR serves via CLI with certain commands:
@@ -37,7 +38,7 @@ toFHIR serves via CLI with certain commands:
 - `info`: See info about the loaded Mapping Job.
 - `load`: Loads a Mapping Job Load the Mapping Job definition file from the path.
 - `run [<url>|<name>]`: Run the task(s). Without a parameter, all task of the loaded Mapping Job are run. A specific task can be indicated with its name or URL.
-- `extract-redcap-schemas [path] [definition-root-url]`: Extracts schemas from the given REDCap data dictionary file. Schemas will be annotated with the given definition root url.
+- `extract-redcap-schemas [path] [definition-root-url] [encoding]`: Extracts schemas from the given REDCap data dictionary file. Schemas will be annotated with the given definition root url. If the encoding of CSV file is different from UTF-8, you should provide it.
 - `stop`: Stop the execution of the MappingJob (if any).
 - `exit|quit`: Exit the program.
 

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/Boot.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/Boot.scala
@@ -23,7 +23,8 @@ object Boot extends App {
       // get parameters
       val dataDictionary = options.get("data-dictionary").map(_.asInstanceOf[String])
       val definitionRootUrl = options.get("definition-root-url").map(_.asInstanceOf[String])
-      val commandArgs: Seq[String] = Seq(dataDictionary, definitionRootUrl).filter(arg => arg.nonEmpty).map(arg => arg.get)
+      val encoding = options.get("encoding").map(_.asInstanceOf[String])
+      val commandArgs: Seq[String] = Seq(dataDictionary, definitionRootUrl, encoding).filter(arg => arg.nonEmpty).map(arg => arg.get)
       // run command
       CommandFactory.apply("extract-redcap-schemas").execute(commandArgs, CommandExecutionContext(toFhirEngine))
     }

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/cli/CommandLineInterface.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/cli/CommandLineInterface.scala
@@ -185,6 +185,8 @@ object CommandLineInterface {
         nextArg(map ++ Map("data-dictionary" -> value), tail)
       case "--definition-root-url" :: value :: tail =>
         nextArg(map ++ Map("definition-root-url" -> value), tail)
+      case "--encoding" :: value :: tail =>
+        nextArg(map ++ Map("encoding" -> value), tail)
       case str :: tail =>
         nextArg(map ++ Map("command" -> str), tail)
       case unknown :: _ =>

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/cli/ExtractRedCapSchemas.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/cli/ExtractRedCapSchemas.scala
@@ -12,6 +12,12 @@ import org.json4s.jackson.Serialization.writePretty
  * Command to extract schemas from a REDCap data dictionary.
  * */
 class ExtractRedCapSchemas extends Command {
+  /**
+   * @param args The list of arguments.
+   *             The first argument is the path of REDCap data dictionary file.
+   *             The second argument is the definition root url.
+   *             The third argument is the encoding of CSV file (OPTIONAL).
+   */
   override def execute(args: Seq[String], context: CommandExecutionContext): CommandExecutionContext = {
     if (args.isEmpty) {
       println("extract-redcap-schemas command requires the path of RedCap data dictionary to extract from and definition root url.")
@@ -23,7 +29,7 @@ class ExtractRedCapSchemas extends Command {
       val filePath = args.head
       try {
         // read REDCap data dictionary
-        val content: Seq[Map[String, String]] = CsvUtil.readFromCSV(filePath)
+        val content: Seq[Map[String, String]] = CsvUtil.readFromCSV(filePath,args.lift(2).getOrElse("UTF-8"))
         // extract schemas
         val fhirResources: Seq[Resource] = RedCapUtil.extractSchemas(content, args(1))
         // write each schema as a file

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/cli/Help.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/cli/Help.scala
@@ -9,7 +9,7 @@ class Help extends Command {
       "\trun [<url>|<name>] - Run the task(s). Without a parameter, all task of the loaded Mapping Job are run. A specific task can be indicated with its name or URL.\n" +
       "\thelp - See the available commands and their use.\n" +
       "\tstop - Stop the execution of the MappingJob (if any).\n" +
-      "\textract-redcap-schemas <path> <definition-root-url> - Extracts schemas from the given REDCap data dictionary file. Schemas will be annotated with the given definition root url.\n" +
+      "\textract-redcap-schemas <path> <definition-root-url> <encoding> - Extracts schemas from the given REDCap data dictionary file. Schemas will be annotated with the given definition root url. If the encoding of CSV file is different from UTF-8, you should provide it.\n" +
       "\texit|quit - Exit the program.\n")
     context
   }

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/util/CsvUtil.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/util/CsvUtil.scala
@@ -2,8 +2,8 @@ package io.tofhir.engine.util
 
 import com.fasterxml.jackson.databind.MappingIterator
 import com.fasterxml.jackson.dataformat.csv.{CsvMapper, CsvSchema}
+import java.io.{File, FileInputStream, InputStreamReader}
 
-import java.io.File
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.jdk.javaapi.CollectionConverters
 
@@ -12,9 +12,10 @@ object CsvUtil {
   /**
    * Read the CSV file from the given filePath and return a Sequence where each element is a Map[column_name -> value)
    * @param filePath  File path
+   * @param encoding The encoding of CSV file whose default value is UTF-8
    * @return
    */
-  def readFromCSV(filePath: String): Seq[Map[String, String]] = {
+  def readFromCSV(filePath: String, encoding: String = "UTF-8"): Seq[Map[String, String]] = {
       val csvFile = new File(filePath)
       val csvMapper = new CsvMapper()
       val csvSchema = CsvSchema.emptySchema().withHeader()
@@ -22,7 +23,7 @@ object CsvUtil {
       val mappingIterator:MappingIterator[java.util.Map[String, String]] =
         csvMapper.readerFor(classOf[java.util.Map[String, String]]) // read each line into a Map[String, String]
           .`with`(csvSchema) // where the key of the map will be the column name according to the first (header) row
-          .readValues(csvFile)
+          .readValues(new InputStreamReader(new FileInputStream(csvFile), encoding)) // read CSV with the given encoding
 
       val javaList: java.util.List[java.util.Map[String, String]] =  mappingIterator.readAll() // Read all lines as a List of Map
 


### PR DESCRIPTION
toFhir provides a functionality to convert a REDCap Data Dictionary file into a Schema. However, when the CSV file has an encoding different from UTF-8, this process fails. Therefore, I've extended the CSV reader with an encoding option and modified corresponding command of tofhir-engine to make use of a REDCap Data Dictionary files with different encodings.