### PR TITLE
:bug: fix: check entity ids (MappingJob and Mapping) with file names

### DIFF
--- a/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
@@ -10,6 +10,7 @@ import io.tofhir.engine.util.FileUtils
 import io.tofhir.engine.util.FileUtils.FileExtensions
 import io.tofhir.server.model._
 import io.tofhir.server.service.project.ProjectFolderRepository
+import io.tofhir.server.util.FileOperations
 import org.json4s.jackson.Serialization.writePretty
 
 import java.io.{File, FileWriter}
@@ -184,7 +185,10 @@ override def getJob(projectId: String, id: String): Future[Option[FhirMappingJob
         val source = Source.fromFile(file, StandardCharsets.UTF_8.name()) // read the JSON file
         val fileContent = try source.mkString finally source.close()
         val job = fileContent.parseJson.extract[FhirMappingJob]
-        fhirJobMap.put(job.id, job)
+        // discard if the job id and file name not match
+        if(FileOperations.checkFileNameMatchesEntityId(job.id, file, "job")) {
+          fhirJobMap.put(job.id, job)
+        }
       }
       map.put(projectDirectory.getName, fhirJobMap)
     }

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
@@ -12,6 +12,8 @@ import org.json4s.jackson.Serialization.writePretty
 import java.io.{File, FileWriter}
 import java.nio.charset.StandardCharsets
 import io.onfhir.api.util.IOUtil
+import io.tofhir.server.util.FileOperations
+
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.io.Source
@@ -202,7 +204,10 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
         val source = Source.fromFile(file, StandardCharsets.UTF_8.name()) // read the JSON file
         val fileContent = try source.mkString finally source.close()
         val fhirMapping = fileContent.parseJson.extract[FhirMapping]
-        fhirMappingMap.put(fhirMapping.id, fhirMapping)
+        // discard if the mapping id and file name not match
+        if (FileOperations.checkFileNameMatchesEntityId(fhirMapping.id, file, "mapping")) {
+          fhirMappingMap.put(fhirMapping.id, fhirMapping)
+        }
       }
       map.put(projectDirectory.getName, fhirMappingMap)
     }

--- a/tofhir-server/src/main/scala/io/tofhir/server/util/FileOperations.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/util/FileOperations.scala
@@ -6,6 +6,7 @@ import com.typesafe.scalalogging.Logger
 import io.onfhir.util.JsonFormatter._
 import io.tofhir.engine.Execution.actorSystem
 import io.tofhir.engine.Execution.actorSystem.dispatcher
+import io.tofhir.engine.util.FileUtils.FileExtensions
 import io.tofhir.server.model.InternalError
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -114,6 +115,22 @@ object FileOperations {
       .map(_ => {})
       .recover(e => throw InternalError("Error while writing file.", e.getMessage))
 
+  }
+
+  /**
+   * Check whether the file name matches with the entity id
+   * @param entityId id of the entity e.g. job id, mapping id
+   * @param file file to whose name will be checked
+   * @param entityType type of the entity e.g. job, mapping
+   * @return true if the file name matches with the entity id, false otherwise
+   */
+  def checkFileNameMatchesEntityId(entityId: String, file: File, entityType: String): Boolean = {
+    if (!entityId.equals(file.getName.replace(FileExtensions.JSON.toString, ""))) {
+      logger.warn(s"Discarding ${entityType} definition with id ${entityId} as it does not match with the file name ${file.getName}")
+      false
+    } else {
+      true
+    }
   }
 }
 


### PR DESCRIPTION
fixes this bullet on issue [12](https://gitlab.srdc.com.tr/onfhir/tofhir-web/-/issues/12:)
Considering that we use identifiers of project concepts such as jobs as file names, we should discard concepts with inconsistent id and file name while loading concepts from the file system (e.g. job file name: ucl, job id: ucl-mapping job). If we load anyway, a subsequent save operation creates a new file which conflicts the initial file.