### PR TITLE
Fix issue 88

### DIFF
--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/BaseDataSourceReader.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/BaseDataSourceReader.scala
@@ -18,9 +18,10 @@ abstract class BaseDataSourceReader[T <: FhirMappingSourceContext, S<:DataSource
    * @param schema          Schema for the source data
    * @param timeRange       Time range for the data to read if given
    * @param limit           Limit the number of rows to read
+   * @param jobId           The identifier of mapping job which executes the mapping
    * @return
    */
-  def read(mappingSource: T, sourceSettings:S, schema: Option[StructType], timeRange: Option[(LocalDateTime, LocalDateTime)] = Option.empty, limit: Option[Int]): DataFrame
+  def read(mappingSource: T, sourceSettings:S, schema: Option[StructType], timeRange: Option[(LocalDateTime, LocalDateTime)] = Option.empty, limit: Option[Int], jobId: Option[String]): DataFrame
 
   /**
    * Whether this reader needs a data type validation for columns after reading the source

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/FileDataSourceReader.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/FileDataSourceReader.scala
@@ -1,7 +1,9 @@
 package io.tofhir.engine.data.read
 
+import com.typesafe.scalalogging.Logger
 import io.tofhir.engine.model.{FileSystemSource, FileSystemSourceSettings, SourceFileFormats}
 import io.tofhir.engine.util.FileUtils
+import org.apache.spark.sql.functions.{input_file_name, udf}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -13,19 +15,24 @@ import java.time.LocalDateTime
  * @param spark Spark session
  */
 class FileDataSourceReader(spark: SparkSession) extends BaseDataSourceReader[FileSystemSource, FileSystemSourceSettings] {
+
+  private val logger: Logger = Logger(this.getClass)
   /**
    * Read the source data
    *
    * @param mappingSource Context/configuration information for mapping source
    * @param schema        Optional schema for the source
    * @param limit         Limit the number of rows to read
+   * @param jobId         The identifier of mapping job which executes the mapping
    * @return
    */
-  override def read(mappingSource: FileSystemSource, sourceSettings:FileSystemSourceSettings, schema: Option[StructType], timeRange: Option[(LocalDateTime, LocalDateTime)], limit: Option[Int] = Option.empty): DataFrame = {
+  override def read(mappingSource: FileSystemSource, sourceSettings:FileSystemSourceSettings, schema: Option[StructType], timeRange: Option[(LocalDateTime, LocalDateTime)], limit: Option[Int] = Option.empty,jobId: Option[String] = Option.empty): DataFrame = {
     val finalPath = FileUtils.getPath(sourceSettings.dataFolderPath, mappingSource.path).toAbsolutePath.toString
 
     val isDistinct = mappingSource.options.get("distinct").contains("true")
 
+    //index of the row being read by Spark
+    var rowIndex: Integer = 0
     //Based on source type
     val resultDf = mappingSource.sourceType match {
         case SourceFileFormats.CSV =>
@@ -46,6 +53,13 @@ class FileDataSourceReader(spark: SparkSession) extends BaseDataSourceReader[Fil
               .options(otherOptions)
               .schema(csvSchema.orNull)
               .csv(finalPath)
+              // add a dummy column called 'filename' using a udf function to print a log when the data reading is
+              // started for a file. indexFn function, which is a parameter of logStartOfDataReading function, increments
+              // rowIndex and returns it for each row
+              .withColumn("filename",logStartOfDataReading(indexFn = () => {
+                rowIndex += 1
+                rowIndex
+              },logger = logger,jobId =  jobId)(input_file_name))
           else
             spark.read
               .option("pathGlobFilter", fileFilter) // Ignore files without csv extension in default
@@ -58,11 +72,25 @@ class FileDataSourceReader(spark: SparkSession) extends BaseDataSourceReader[Fil
         case SourceFileFormats.JSON =>
           if(sourceSettings.asStream)
             spark.readStream.options(mappingSource.options).schema(schema.orNull).json(finalPath)
+              // add a dummy column called 'filename' to print a log when the data reading is started for a file
+              // indexFn function, which is a parameter of logStartOfDataReading function, increments rowIndex and
+              // returns it for each row
+              .withColumn("filename", logStartOfDataReading(indexFn = () => {
+                rowIndex += 1
+                rowIndex
+              }, logger = logger, jobId = jobId)(input_file_name))
           else
             spark.read.options(mappingSource.options).schema(schema.orNull).json(finalPath)
         case SourceFileFormats.PARQUET =>
           if(sourceSettings.asStream)
             spark.readStream.options(mappingSource.options).schema(schema.orNull).parquet(finalPath)
+              // add a dummy column called 'filename' to print a log when the data reading is started for a file
+              // indexFn function, which is a parameter of logStartOfDataReading function, increments rowIndex and
+              // returns it for each row
+              .withColumn("filename", logStartOfDataReading(indexFn = () => {
+                rowIndex += 1
+                rowIndex
+              }, logger = logger, jobId = jobId)(input_file_name))
           else
             spark.read.options(mappingSource.options).schema(schema.orNull).parquet(finalPath)
         case _ => throw new NotImplementedError()
@@ -72,4 +100,22 @@ class FileDataSourceReader(spark: SparkSession) extends BaseDataSourceReader[Fil
     else
       resultDf
   }
+
+  /**
+   * A user-defined function i.e. udf to print a log when data reading is started for a file. udf takes the
+   * name of input file being read and returns it after logging a message to indicate that data reading is started and
+   * it may take a while. It makes use of the given indexFn function to decide whether to print a log. If it returns 'one'
+   * i.e. the first record, the log is printed.
+   * @param indexFn A function which returns the index of current row which is being read by Spark
+   * @param logger  Logger instance
+   * @param jobId   The identifier of mapping job which executes the mapping
+   * @return a user-defined function to print a log when data reading is started for a file
+   * */
+  private def logStartOfDataReading(indexFn: () => Integer, logger: Logger, jobId: Option[String]) = udf((fileName: String) => {
+    val index = indexFn()
+    if (index == 1) {
+      logger.info(s"Reading data from $fileName for the mapping job ${jobId.getOrElse("")}. This may take a while...")
+    }
+    fileName
+  })
 }

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/KafkaSourceReader.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/KafkaSourceReader.scala
@@ -24,9 +24,10 @@ class KafkaSourceReader(spark: SparkSession) extends BaseDataSourceReader[KafkaS
    * @param mappingSource Context/configuration information for mapping source
    * @param schema        Schema for the source
    * @param limit         Limit the number of rows to read
+   * @param jobId         The identifier of mapping job which executes the mapping
    * @return
    */
-  override def read(mappingSource: KafkaSource, sourceSettings: KafkaSourceSettings, schema: Option[StructType] = Option.empty, timeRange: Option[(LocalDateTime, LocalDateTime)] = Option.empty, limit: Option[Int] = Option.empty): DataFrame = {
+  override def read(mappingSource: KafkaSource, sourceSettings: KafkaSourceSettings, schema: Option[StructType] = Option.empty, timeRange: Option[(LocalDateTime, LocalDateTime)] = Option.empty, limit: Option[Int] = Option.empty, jobId: Option[String] = Option.empty): DataFrame = {
     import spark.implicits._
 
     if (schema.isEmpty) {

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/SourceHandler.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/SourceHandler.scala
@@ -21,6 +21,7 @@ object SourceHandler {
    * @param schema         Schema of the input supplied by the mapping definition
    * @param timeRange      Time range for the data to read if given
    * @param limit          Limit the number of rows to read
+   * @param jobId          The identifier of mapping job which executes the mapping
    * @tparam T Type of the source definition class
    * @tparam S Type of the source settings class
    * @return
@@ -32,7 +33,8 @@ object SourceHandler {
                                                                           sourceSettings: S,
                                                                           schema: Option[StructType],
                                                                           timeRange: Option[(LocalDateTime, LocalDateTime)] = Option.empty,
-                                                                          limit: Option[Int] = Option.empty
+                                                                          limit: Option[Int] = Option.empty,
+                                                                          jobId: Option[String] = Option.empty
                                                                         ): DataFrame = {
     val reader =
       DataSourceReaderFactory
@@ -40,7 +42,7 @@ object SourceHandler {
 
     val sourceData =
       reader
-        .read(mappingSource, sourceSettings, schema, timeRange, limit)
+        .read( mappingSource, sourceSettings, schema, timeRange, limit, jobId = jobId)
 
     val finalSourceData =
       //If there is some preprocessing SQL defined, apply it

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/SqlSourceReader.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/SqlSourceReader.scala
@@ -23,9 +23,10 @@ class SqlSourceReader(spark: SparkSession) extends BaseDataSourceReader[SqlSourc
    * @param schema          Schema for the source data
    * @param timeRange       Time range for the data to read if given
    * @param limit           Limit the number of rows to read
+   * @param jobId           The identifier of mapping job which executes the mapping
    * @return
    */
-  override def read(mappingSource: SqlSource, sourceSettings: SqlSourceSettings, schema: Option[StructType], timeRange: Option[(LocalDateTime, LocalDateTime)], limit: Option[Int]): DataFrame = {
+  override def read(mappingSource: SqlSource, sourceSettings: SqlSourceSettings, schema: Option[StructType], timeRange: Option[(LocalDateTime, LocalDateTime)], limit: Option[Int], jobId: Option[String]): DataFrame = {
     if (mappingSource.tableName.isDefined && mappingSource.query.isDefined) {
       throw FhirMappingException(s"Both table name: ${mappingSource.tableName.get} and query: ${mappingSource.query.get} should not be specified at the same time.")
     }

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/ExecutionService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/ExecutionService.scala
@@ -122,7 +122,7 @@ class ExecutionService(jobRepository: IJobRepository, mappingRepository: IMappin
           testResourceCreationRequest.fhirMappingTask.copy(mapping = Some(mappingWithNormalizedContextUrls))
       }
 
-    val (fhirMapping, dataSourceSettings, dataFrame) = fhirMappingJobManager.readJoinSourceData(mappingTask, mappingJob.sourceSettings)
+    val (fhirMapping, dataSourceSettings, dataFrame) = fhirMappingJobManager.readJoinSourceData(mappingTask, mappingJob.sourceSettings, jobId = Some(jobId))
     val selected = DataFrameUtil.applyResourceFilter(dataFrame, testResourceCreationRequest.resourceFilter)
     fhirMappingJobManager.executeTask(mappingJob.id, fhirMapping, selected, dataSourceSettings, mappingJob.terminologyServiceSettings, mappingJob.getIdentityServiceSettings())
       .map { dataFrame =>


### PR DESCRIPTION
It fixes the following issue: https://github.com/srdc/tofhir/issues/88

Let's assume we are running a streaming mapping job which reads a file. Here is the scenario to describe what has been changed in the logging:

### Before MR
1. Writing resources
  Created FHIR resources will be written to the given FHIR repository URL:http://localhost:8081/fhir
  Batch Update request will be sent to the FHIR repository for 1 resources.
2. Result
  toFHIR batch mapping result (PARTIAL_SUCCESS) for execution 'b0329c99-b3d5-453e-8491-2ce6bd7c0900' of job 'medic-labresults-transformation' in project ''!
  Number of of Invalid Rows:  0
  Number  of Not Mapped:  0
  Number  of Failed writes: 0
  Number  of Written FHIR resources:  1

### After MR
1. Job started
  Streaming mapping job medic-labresults-transformation is started and waiting for the data...
2. Reading data 
  Reading data from file:///C:/Users/doguk/Desktop/DT4H/Repositories/medic-integrations/medic-data/labresults_csv/Patient_anonymised-9111443.csv for the mapping job medic-labresults-transformation. This may take a while...
3. Writing resources
  Created FHIR resources will be written to the given FHIR repository URL:http://localhost:8081/fhir
  Batch Update request will be sent to the FHIR repository for 1 resources.
4. Result
  toFHIR batch mapping result (PARTIAL_SUCCESS) for execution '474a0a71-845e-47af-98e6-261e0643b5ba' of job 'medic-labresults-transformation' in project ''!
  Number  of Invalid Rows:  0
  Number  of Not Mapped:  0
  Number  of Failed writes: 0
  Number  of Written FHIR resources:  1

MR adds the "Job started" (Step 1) and "Reading data" (Step 2) logs.