### PR TITLE
Remove DomainResource extension from SimpleStructureDefinition

### DIFF
--- a/tofhir-server/src/main/scala/io/tofhir/server/service/SimpleStructureDefinitionService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/SimpleStructureDefinitionService.scala
@@ -91,6 +91,10 @@ class SimpleStructureDefinitionService(fhirConfig: BaseFhirConfig) {
             // But, filter out extension, modifierExtension and id fields if they come from Element and BackboneElement profiles. Otherwise the SimpleStructureDefinition becomes huge!
             if (pr.url.endsWith("Element") || pr.url.endsWith("BackboneElement"))
               pr.elementRestrictions.filterNot(er => er._1 == "extension" || er._1 == "modifierExtension" || er._1 == "id")
+            // remove the extensions coming from DomainResource. SimpleStructureDefinition will include "extension" element
+            // iff the profile has some slices for it.
+            else if (pr.url.endsWith("DomainResource"))
+              pr.elementRestrictions.filterNot(er => er._1 == "extension")
             else
               pr.elementRestrictions
           }

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/SimpleStructureDefinitionService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/SimpleStructureDefinitionService.scala
@@ -94,7 +94,7 @@ class SimpleStructureDefinitionService(fhirConfig: BaseFhirConfig) {
             // remove the extensions coming from DomainResource. SimpleStructureDefinition will include "extension" element
             // iff the profile has some slices for it.
             else if (pr.url.endsWith("DomainResource"))
-              pr.elementRestrictions.filterNot(er => er._1 == "extension")
+              pr.elementRestrictions.filterNot(er => er._1 == "extension"|| er._1 == "modifierExtension")
             else
               pr.elementRestrictions
           }


### PR DESCRIPTION
If no extension slices are defined for the profile, the resulting SimpleStructureDefinition will not include any extension element.
If it has some extension slices, they will be added to  SimpleStructureDefinition 