### PR TITLE
Fix checkpoint and commit directory locations

### DIFF
--- a/tofhir-engine/pom.xml
+++ b/tofhir-engine/pom.xml
@@ -57,7 +57,7 @@
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <membersOnlySuites>io.tofhir.test</membersOnlySuites>
+                            <wildcardSuites>io.tofhir.test</wildcardSuites>
                         </configuration>
                     </execution>
                     <execution>

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/config/ToFhirConfig.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/config/ToFhirConfig.scala
@@ -26,7 +26,7 @@ object ToFhirConfig {
   /** Master url of the Spark cluster */
   lazy val sparkMaster: String = Try(sparkConfig.getString("master")).getOrElse("local[4]")
   /** Directory to keep Spark's checkpoints created  */
-  lazy val sparkCheckpointDirectory: String = FileUtils.getPath(engineConfig.contextPath, Try(sparkConfig.getString("checkpoint-dir")).getOrElse("checkpoint")).toString
+  lazy val sparkCheckpointDirectory: String = FileUtils.getPath(Try(sparkConfig.getString("checkpoint-dir")).getOrElse("checkpoint")).toString
   /**
    * Default configurations for spark
    */

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/config/ToFhirEngineConfig.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/config/ToFhirEngineConfig.scala
@@ -50,10 +50,10 @@ class ToFhirEngineConfig(toFhirEngineConfig: Config) {
   lazy val toFhirDbFolderPath: String = Try(toFhirEngineConfig.getString("db-path")).getOrElse("tofhir-db")
 
   /** The parent-folder where the data sources of errors received while running mapping are stored. */
-  lazy val erroneousRecordsFolder: String = FileUtils.getPath(contextPath, Try(toFhirEngineConfig.getString("archiving.erroneous-records-folder")).getOrElse("erroneous-records-folder")).toString
+  lazy val erroneousRecordsFolder: String = FileUtils.getPath(Try(toFhirEngineConfig.getString("archiving.erroneous-records-folder")).getOrElse("erroneous-records-folder")).toString
 
   /** Folder path where the archive of the processed source data is stored. */
-  lazy val archiveFolder: String = FileUtils.getPath(contextPath, Try(toFhirEngineConfig.getString("archiving.archive-folder")).getOrElse("archive-folder")).toString
+  lazy val archiveFolder: String = FileUtils.getPath(Try(toFhirEngineConfig.getString("archiving.archive-folder")).getOrElse("archive-folder")).toString
 
   /** Period (in milliseconds) to run archiving task for file streaming jobs */
   lazy val streamArchivingFrequency: Int = Try(toFhirEngineConfig.getInt("archiving.stream-archiving-frequency")).toOption.getOrElse(5000)

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingJobExecution.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingJobExecution.scala
@@ -2,9 +2,10 @@ package io.tofhir.engine.model
 
 import io.tofhir.engine.config.{ErrorHandlingType, ToFhirConfig}
 import io.tofhir.engine.config.ErrorHandlingType.ErrorHandlingType
-import io.tofhir.engine.util.{FileUtils, SparkUtil}
+import io.tofhir.engine.util.SparkUtil
 import org.apache.spark.sql.streaming.StreamingQuery
 
+import java.nio.file.Paths
 import java.util.UUID
 import java.util.regex.Pattern
 
@@ -80,7 +81,7 @@ case class FhirMappingJobExecution(id: String = UUID.randomUUID().toString,
    * @return Directory path in which the checkpoints will be managed
    */
   def getCheckpointDirectory(mappingUrl: String): String =
-    s"${FileUtils.getPath(ToFhirConfig.sparkCheckpointDirectory, job.id, mappingUrl.hashCode.toString).toString}"
+    Paths.get(ToFhirConfig.sparkCheckpointDirectory, job.id, mappingUrl.hashCode.toString).toString
 
   /**
    * Creates a commit directory for a mapping included in a job
@@ -89,7 +90,7 @@ case class FhirMappingJobExecution(id: String = UUID.randomUUID().toString,
    * @return Directory path in which the commits will be managed
    */
   def getCommitDirectory(mappingUrl: String): String = {
-    SparkUtil.getCommitDirectoryPath(FileUtils.getPath(getCheckpointDirectory(mappingUrl)))
+    SparkUtil.getCommitDirectoryPath(Paths.get(getCheckpointDirectory(mappingUrl)))
   }
 
   /**
@@ -99,7 +100,7 @@ case class FhirMappingJobExecution(id: String = UUID.randomUUID().toString,
    * @return Directory path in which the sources will be managed
    */
   def getSourceDirectory(mappingUrl: String): String = {
-    SparkUtil.getSourceDirectoryPath(FileUtils.getPath(getCheckpointDirectory(mappingUrl)))
+    SparkUtil.getSourceDirectoryPath(Paths.get(getCheckpointDirectory(mappingUrl)))
   }
 
   /**
@@ -112,7 +113,7 @@ case class FhirMappingJobExecution(id: String = UUID.randomUUID().toString,
    * @return
    */
   def getErrorOutputDirectory(mappingUrl: String, errorType: String): String =
-    FileUtils.getPath(ToFhirConfig.engineConfig.erroneousRecordsFolder, errorType, s"job-${job.id}", s"execution-${id}",
+    Paths.get(ToFhirConfig.engineConfig.erroneousRecordsFolder, errorType, s"job-${job.id}", s"execution-${id}",
       this.convertUrlToAlphaNumeric(mappingUrl)).toString
 
 

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/util/SparkUtil.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/util/SparkUtil.scala
@@ -1,10 +1,10 @@
 package io.tofhir.engine.util
 
-import io.tofhir.engine.config.ToFhirConfig
 import io.tofhir.engine.util.FhirMappingJobFormatter.formats
 import org.json4s.jackson.JsonMethods
 
 import java.io.{File, PrintWriter}
+import java.net.URI
 import java.nio.file.{Path, Paths}
 import scala.io.Source
 
@@ -38,13 +38,13 @@ object SparkUtil {
   }
 
   /**
-   * Write csv path to source file
+   * Write csv URI to source file
    *
    * @param sourceWriter Writer for source file
    * @param testCsvFile  Selected csv file
    */
   def writeToSourceFile(sourceWriter: PrintWriter, testCsvFile: File): Unit = {
-    sourceWriter.write(s"{\"path\":\"${testCsvFile.getAbsolutePath.replace("\\", "\\\\")}\"}\n")
+    sourceWriter.write(s"{\"path\":\"${testCsvFile.toURI.toString.replace("\\", "\\\\")}\"}\n")
   }
 
   /**
@@ -61,10 +61,9 @@ object SparkUtil {
       .flatMap(line => {
         // Some lines do not contain the desired information
         try {
-          // Source name is specified in the "path" field of a json object
+          // Source URI is specified in the "path" field of a json object
           val path: String = (JsonMethods.parse(line) \ "path").extract[String]
-          Some(FileUtils.getPath(ToFhirConfig.engineConfig.contextPath, path).toFile)
-
+          Some(Paths.get(new URI(path)).toFile)
         } catch {
           case _: Throwable => None
         }

--- a/tofhir-engine/src/test/resources/application.conf
+++ b/tofhir-engine/src/test/resources/application.conf
@@ -3,7 +3,7 @@ tofhir {
 
   # A path to a file/directory from where any File system readings should use within the mappingjob definition.
   # e.g., FileSystemSourceSettings.dataFolderPath or LocalFhirTerminologyServiceSettings.folderPath
-  context-path = "conf"
+  context-path = "testcontext"
 
   mappings = {
 

--- a/tofhir-engine/src/test/resources/application.conf
+++ b/tofhir-engine/src/test/resources/application.conf
@@ -3,7 +3,7 @@ tofhir {
 
   # A path to a file/directory from where any File system readings should use within the mappingjob definition.
   # e.g., FileSystemSourceSettings.dataFolderPath or LocalFhirTerminologyServiceSettings.folderPath
-  context-path = "./"
+  context-path = "conf"
 
   mappings = {
 

--- a/tofhir-engine/src/test/scala/io/tofhir/test/engine/execution/FileStreamInputArchiverTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/engine/execution/FileStreamInputArchiverTest.scala
@@ -152,10 +152,10 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     SparkUtil.writeToSourceFile(sourceWriter, test2CsvFile)
     sourceWriter.close()
 
-    // Access getInputFile method of FileStreamInputArchiver using reflection
-    val FileStreamInputArchiverInstance = FileStreamInputArchiver
-    val methodSymbol = typeOf[FileStreamInputArchiver.type].decl(TermName("getInputFiles")).asMethod
-    val methodMirror = runtimeMirror(getClass.getClassLoader).reflect(FileStreamInputArchiverInstance)
+    // Access getInputFile method of SparkUtil using reflection
+    val sparkUtilInstance = SparkUtil
+    val methodSymbol = typeOf[SparkUtil.type].decl(TermName("getInputFiles")).asMethod
+    val methodMirror = runtimeMirror(getClass.getClassLoader).reflect(sparkUtilInstance)
     val getInputFilesMethod = methodMirror.reflectMethod(methodSymbol)
 
     // Call reflected getInputFile function
@@ -191,10 +191,10 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     commitWriter2.write("test")
     commitWriter2.close()
 
-    // Access getLastCommitOffset method of FileStreamInputArchiver using reflection
-    val FileStreamInputArchiverInstance = FileStreamInputArchiver
-    val methodSymbol = typeOf[FileStreamInputArchiver.type].decl(TermName("getLastCommitOffset")).asMethod
-    val methodMirror = runtimeMirror(getClass.getClassLoader).reflect(FileStreamInputArchiverInstance)
+    // Access getLastCommitOffset method of SparkUtil using reflection
+    val SparkUtilInstance = SparkUtil
+    val methodSymbol = typeOf[SparkUtil.type].decl(TermName("getLastCommitOffset")).asMethod
+    val methodMirror = runtimeMirror(getClass.getClassLoader).reflect(SparkUtilInstance)
     val getLastCommitOffsetMethod = methodMirror.reflectMethod(methodSymbol)
 
     // Call reflected getLastCommitOffset function

--- a/tofhir-engine/src/test/scala/io/tofhir/test/engine/execution/FileStreamInputArchiverTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/engine/execution/FileStreamInputArchiverTest.scala
@@ -43,12 +43,9 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     val testCsvFile: File = initializeSparkFiles(jobId, mappingUrl)
 
     // Find the relative path between the workspace folder and the file to be archived
-    val relPath = FileUtils.getPath("").toAbsolutePath.relativize(FileUtils.getPath(ToFhirConfig.sparkCheckpointDirectory, "test.csv").toAbsolutePath)
-    val expectedRelPath = FileUtils.getPath(ToFhirConfig.sparkCheckpointDirectory, "test.csv")
-    // validate relPath
-    relPath shouldBe expectedRelPath
+    val relPath = FileUtils.getPath("").toAbsolutePath.relativize(Paths.get(ToFhirConfig.sparkCheckpointDirectory, "test.csv").toAbsolutePath)
     // The relative path is appended to the base archive folder so that the path of the original input file is preserved
-    val finalArchivePath = FileUtils.getPath(ToFhirConfig.engineConfig.archiveFolder, relPath.toString)
+    val finalArchivePath = Paths.get(ToFhirConfig.engineConfig.archiveFolder, relPath.toString)
 
     // Check whether archiving file does not exist and csv file exists
     finalArchivePath.toFile.exists() shouldBe false
@@ -62,8 +59,8 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     testCsvFile.exists() shouldBe false
 
     // Clean test directory
-    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(ToFhirConfig.sparkCheckpointDirectory).toFile)
-    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(ToFhirConfig.engineConfig.archiveFolder).toFile)
+    org.apache.commons.io.FileUtils.deleteDirectory(new File(ToFhirConfig.sparkCheckpointDirectory))
+    org.apache.commons.io.FileUtils.deleteDirectory(new File(ToFhirConfig.engineConfig.archiveFolder))
   }
 
   "FileStreamInputArchiver" should "apply deletion for a streaming job" in {
@@ -81,7 +78,7 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     testCsvFile.exists() shouldBe false
 
     // Clean test directory
-    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(ToFhirConfig.sparkCheckpointDirectory).toFile)
+    org.apache.commons.io.FileUtils.deleteDirectory(new File(ToFhirConfig.sparkCheckpointDirectory))
   }
 
   "FileStreamInputArchiver" should "apply archiving for a batch job" in{
@@ -91,11 +88,8 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
 
     // Find the relative path between the workspace folder and the file to be archived
     val relPath = FileUtils.getPath("").toAbsolutePath.relativize(inputFile.toPath.toAbsolutePath)
-    val expectedRelPath = inputFile.toPath
-    // validate relPath
-    relPath shouldBe expectedRelPath
     // The relative path is appended to the base archive folder so that the path of the original input file is preserved
-    val finalArchivePath = FileUtils.getPath(ToFhirConfig.engineConfig.archiveFolder, relPath.toString)
+    val finalArchivePath = Paths.get(ToFhirConfig.engineConfig.archiveFolder, relPath.toString)
 
     // Check whether archiving file does not exist and input file exists
     finalArchivePath.toFile.exists() shouldBe false
@@ -109,8 +103,8 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     inputFile.exists() shouldBe false
 
     // Clean test directories
-    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(ToFhirConfig.engineConfig.contextPath, sourceFolderPath).toFile)
-    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(ToFhirConfig.engineConfig.archiveFolder).toFile)
+    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(sourceFolderPath).toFile)
+    org.apache.commons.io.FileUtils.deleteDirectory(new File(ToFhirConfig.engineConfig.archiveFolder))
   }
 
   "FileStreamInputArchiver" should "apply deletion for a batch job" in{
@@ -128,7 +122,7 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     inputFile.exists() shouldBe false
 
     // Clean test directories
-    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(ToFhirConfig.engineConfig.contextPath, sourceFolderPath).toFile)
+    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(sourceFolderPath).toFile)
   }
 
   "FileStreamInputArchiver" should "get input files" in {
@@ -206,7 +200,7 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath("test-archiver").toFile)
   }
 
-  "FileStreamInputArchiver" should "get last proccessed offset" in {
+  "FileStreamInputArchiver" should "get last processed offset" in {
 
     val mappingUrl = "mocked_mapping_url"
     val jobId = "mocked_job_id_5"
@@ -236,14 +230,14 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
   }
 
   /**
-   * Initialize needed input files.
+   * Creates a dummy input file.
    * @param sourceFolderPath Source folder path for input file
    * @param inputFileName Input file name
    * @return Return input file
    */
   private def initializeInputFiles(sourceFolderPath: String, inputFileName: String): File = {
     // Create a test input file
-    val inputFile = FileUtils.getPath(ToFhirConfig.engineConfig.contextPath, sourceFolderPath, inputFileName).toFile
+    val inputFile = FileUtils.getPath(sourceFolderPath, inputFileName).toFile
     inputFile.getParentFile.mkdirs()
     // Write test to input file
     val inputWriter = new PrintWriter(inputFile)
@@ -254,7 +248,10 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
   }
 
   /**
-   * Initialize needed spark files.
+   * Creates the following Spark files for the given mapping:
+   *  - A commit file
+   *  - A source file
+   *  - A test csv file
    * @param jobId Job id of the execution.
    * @param mappingUrl Selected mapping url.
    * @return Return test csv file
@@ -263,7 +260,7 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     // Create a source file to refer location of test.csv
     val sourceFile = getSourceFileFromSparkArchiver(jobId, mappingUrl, "0")
     // Path of test.csv
-    val testCsvFile = FileUtils.getPath(ToFhirConfig.sparkCheckpointDirectory, "test.csv").toFile
+    val testCsvFile = Paths.get(ToFhirConfig.sparkCheckpointDirectory, "test.csv").toFile
     // Ensure the parent directories exist, if not, create them
     sourceFile.getParentFile.mkdirs()
     testCsvFile.getParentFile.mkdirs()
@@ -313,7 +310,7 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
    */
   def getSourceFileFromSparkArchiver(jobId: String, mappingUrl: String, fileName: String): File = {
     Paths.get(
-      SparkUtil.getSourceDirectoryPath(FileUtils.getPath(ToFhirConfig.sparkCheckpointDirectory, jobId, mappingUrl.hashCode.toString)),
+      SparkUtil.getSourceDirectoryPath(Paths.get(ToFhirConfig.sparkCheckpointDirectory, jobId, mappingUrl.hashCode.toString)),
       fileName
     ).toFile
   }
@@ -343,7 +340,7 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
    */
   def getCommitFileFromSparkArchiver(jobId: String, mappingUrl: String, fileName: String): File = {
     Paths.get(
-      SparkUtil.getCommitDirectoryPath(FileUtils.getPath(ToFhirConfig.sparkCheckpointDirectory, jobId, mappingUrl.hashCode.toString)),
+      SparkUtil.getCommitDirectoryPath(Paths.get(ToFhirConfig.sparkCheckpointDirectory, jobId, mappingUrl.hashCode.toString)),
       fileName
     ).toFile
   }

--- a/tofhir-engine/src/test/scala/io/tofhir/test/engine/model/FhirMappingJobExecutionTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/engine/model/FhirMappingJobExecutionTest.scala
@@ -1,9 +1,11 @@
 package io.tofhir.test.engine.model
 
 import io.tofhir.engine.model.{FhirMappingJob, FhirMappingJobExecution, FhirRepositorySinkSettings}
-import io.tofhir.engine.util.{FileUtils, SparkUtil}
+import io.tofhir.engine.util.SparkUtil
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Paths
 
 class FhirMappingJobExecutionTest extends AnyFlatSpec with Matchers{
 
@@ -17,12 +19,12 @@ class FhirMappingJobExecutionTest extends AnyFlatSpec with Matchers{
   "FhirMappingJobExecution" should "get source file" in {
     // Test whether source directory is right
     testExecution.getSourceDirectory(mappingUrl) shouldBe
-      SparkUtil.getSourceDirectoryPath(FileUtils.getPath(testExecution.getCheckpointDirectory(mappingUrl)))
+      SparkUtil.getSourceDirectoryPath(Paths.get(testExecution.getCheckpointDirectory(mappingUrl)))
   }
 
   "FhirMappingJobExecution" should "get commit file" in {
     // Test whether commit directory is right
     testExecution.getCommitDirectory(mappingUrl) shouldBe
-      SparkUtil.getCommitDirectoryPath(FileUtils.getPath(testExecution.getCheckpointDirectory(mappingUrl)))
+      SparkUtil.getCommitDirectoryPath(Paths.get(testExecution.getCheckpointDirectory(mappingUrl)))
   }
 }

--- a/tofhir-engine/src/test/scala/io/tofhir/test/engine/model/FhirMappingJobExecutionTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/engine/model/FhirMappingJobExecutionTest.scala
@@ -1,6 +1,5 @@
 package io.tofhir.test.engine.model
 
-import io.tofhir.engine.config.ToFhirConfig
 import io.tofhir.engine.model.{FhirMappingJob, FhirMappingJobExecution, FhirRepositorySinkSettings}
 import io.tofhir.engine.util.{FileUtils, SparkUtil}
 import org.scalatest.flatspec.AnyFlatSpec

--- a/tofhir-server/src/test/resources/application.conf
+++ b/tofhir-server/src/test/resources/application.conf
@@ -3,7 +3,7 @@ tofhir {
 
   # A path to a file/directory from where any File system readings should use within the mappingjob definition.
   # e.g., FileSystemSourceSettings.dataFolderPath or LocalFhirTerminologyServiceSettings.folderPath
-  context-path = "./"
+  context-path = "conf"
 
   mappings = {
     repository = { # The repository where the mapping definition are kept.

--- a/tofhir-server/src/test/scala/io/tofhir/server/project/MappingExecutionEndpointTest.scala
+++ b/tofhir-server/src/test/scala/io/tofhir/server/project/MappingExecutionEndpointTest.scala
@@ -159,9 +159,9 @@ class MappingExecutionEndpointTest extends BaseEndpointTest {
 
         // test if erroneous records are written to error folder
         success = waitForCondition(10) {
-          val erroneousRecordsFolder = FileUtils.getPath(toFhirEngineConfig.erroneousRecordsFolder, FhirMappingErrorCodes.MAPPING_ERROR)
+          val erroneousRecordsFolder = Paths.get(toFhirEngineConfig.erroneousRecordsFolder, FhirMappingErrorCodes.MAPPING_ERROR)
           erroneousRecordsFolder.toFile.exists() && {
-            val jobFolder = FileUtils.getPath(erroneousRecordsFolder.toString, s"job-${job.id}").toFile
+            val jobFolder = Paths.get(erroneousRecordsFolder.toString, s"job-${job.id}").toFile
             val csvFile = jobFolder.listFiles().head.listFiles().head.listFiles().head
             csvFile.exists() && {
               val csvFileContent = sparkSession.read.option("header", "true").csv(csvFile.getPath)
@@ -372,7 +372,7 @@ class MappingExecutionEndpointTest extends BaseEndpointTest {
   override def beforeAll(): Unit = {
     super.beforeAll()
     org.apache.commons.io.FileUtils.deleteDirectory(new File(fsSinkFolderName))
-    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(toFhirEngineConfig.erroneousRecordsFolder).toFile)
+    org.apache.commons.io.FileUtils.deleteDirectory(Paths.get(toFhirEngineConfig.erroneousRecordsFolder).toFile)
     fsSinkFolder.mkdirs()
     this.createProject(Some("deadbeef-dead-dead-dead-deaddeafbeef"))
   }
@@ -381,6 +381,6 @@ class MappingExecutionEndpointTest extends BaseEndpointTest {
     super.afterAll()
     org.apache.commons.io.FileUtils.deleteDirectory(fsSinkFolder)
     // delete erroneous folder
-    org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.getPath(toFhirEngineConfig.erroneousRecordsFolder).toFile)
+    org.apache.commons.io.FileUtils.deleteDirectory(Paths.get(toFhirEngineConfig.erroneousRecordsFolder).toFile)
   }
 }


### PR DESCRIPTION
If we set **CONTEXT_PATH** variable, checkpoint and commit directory locations are set wrong. They include multiple **CONTEXT_PATH**s in their paths. This MR fixes that problem.

Let's assume **CONTEXT_PATH = conf**
**Before MR :** 
 - Checkpoint location: conf/conf/conf/checkpoint/labresults-transformation-wis/701222302
 - Commit directory: conf/conf/conf/conf/conf/checkpoint/labresults-transformation-wis/701222302/commits

**After MR:**
- Checkpoint location: conf/checkpoint/labresults-transformation-wis/701222302
- Commit directory: conf/checkpoint/labresults-transformation-wis/701222302/commits