### PR TITLE
Handle the case where there is no project directories provided in the configured folders

### DIFF
--- a/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
@@ -205,10 +205,6 @@ override def getJob(projectId: String, id: String): Future[Option[FhirMappingJob
     }
     var directories = Seq.empty[File]
     directories = folder.listFiles.filter(_.isDirectory).toSeq
-    if (directories.isEmpty) {
-      throw new RuntimeException("There is no project folder for job in the repository")
-    }
-
     directories.foreach { projectDirectory =>
       // job-id -> FhirMappingJob
       val fhirJobMap: mutable.Map[String, FhirMappingJob] = mutable.Map.empty

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
@@ -221,8 +221,8 @@ override def getJob(projectId: String, id: String): Future[Option[FhirMappingJob
             fhirJobMap.put(job.id, job)
           }
         }catch{
-          case _: JsonParseException =>
-            logger.error(s"Failed to parse '${file.getPath}'!")
+          case e: Throwable =>
+            logger.error(e.getMessage)
             System.exit(1)
         }
       }

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
@@ -205,6 +205,10 @@ override def getJob(projectId: String, id: String): Future[Option[FhirMappingJob
     }
     var directories = Seq.empty[File]
     directories = folder.listFiles.filter(_.isDirectory).toSeq
+    if (directories.isEmpty) {
+      throw new RuntimeException("There is no project folder for job in the repository")
+    }
+
     directories.foreach { projectDirectory =>
       // job-id -> FhirMappingJob
       val fhirJobMap: mutable.Map[String, FhirMappingJob] = mutable.Map.empty

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/job/JobFolderRepository.scala
@@ -222,7 +222,7 @@ override def getJob(projectId: String, id: String): Future[Option[FhirMappingJob
           }
         }catch{
           case e: Throwable =>
-            logger.error(e.getMessage)
+            logger.error(s"Failed to parse mapping job definition at ${file.getPath}: ${e.getMessage}")
             System.exit(1)
         }
       }

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
@@ -242,8 +242,8 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
             fhirMappingMap.put(fhirMapping.id, fhirMapping)
           }
         }catch{
-          case _: JsonParseException =>
-            logger.error(s"Failed to parse '${file.getPath}'!")
+          case e: Throwable =>
+            logger.error(e.getMessage)
             System.exit(1)
         }
       }

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
@@ -243,7 +243,7 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
           }
         }catch{
           case e: Throwable =>
-            logger.error(e.getMessage)
+            logger.error(s"Failed to parse mapping definition at ${file.getPath}: ${e.getMessage}")
             System.exit(1)
         }
       }

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
@@ -222,9 +222,6 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
     }
     var directories = Seq.empty[File]
     directories = folder.listFiles.filter(_.isDirectory).toSeq
-    if (directories.isEmpty) {
-      throw new RuntimeException("There is no project folder for mapping in the repository")
-    }
     directories.foreach { projectDirectory =>
       // mapping-id -> FhirMapping
       val fhirMappingMap: mutable.Map[String, FhirMapping] = mutable.Map.empty

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
@@ -1,5 +1,7 @@
 package io.tofhir.server.service.mapping
 
+import com.fasterxml.jackson.core.JsonParseException
+import com.typesafe.scalalogging.Logger
 import io.onfhir.util.JsonFormatter._
 import io.tofhir.engine.Execution.actorSystem.dispatcher
 import io.tofhir.engine.model.FhirMapping
@@ -26,6 +28,9 @@ import scala.io.Source
  * @param projectFolderRepository     project repository to update corresponding projects based on updates on the mappings
  */
 class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projectFolderRepository: ProjectFolderRepository) extends IMappingRepository {
+
+  private val logger: Logger = Logger(this.getClass)
+
   // project id -> mapping id -> mapping
   private val mappingDefinitions: mutable.Map[String, mutable.Map[String, FhirMapping]] = initMap(mappingRepositoryFolderPath)
 
@@ -229,10 +234,17 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
       files.foreach { file =>
         val source = Source.fromFile(file, StandardCharsets.UTF_8.name()) // read the JSON file
         val fileContent = try source.mkString finally source.close()
-        val fhirMapping = fileContent.parseJson.extract[FhirMapping]
-        // discard if the mapping id and file name not match
-        if (FileOperations.checkFileNameMatchesEntityId(fhirMapping.id, file, "mapping")) {
-          fhirMappingMap.put(fhirMapping.id, fhirMapping)
+        // Try to parse the file content as FhirMapping
+        try {
+          val fhirMapping = fileContent.parseJson.extract[FhirMapping]
+          // discard if the mapping id and file name not match
+          if (FileOperations.checkFileNameMatchesEntityId(fhirMapping.id, file, "mapping")) {
+            fhirMappingMap.put(fhirMapping.id, fhirMapping)
+          }
+        }catch{
+          case _: JsonParseException =>
+            logger.error(s"Failed to parse '${file.getPath}'!")
+            System.exit(1)
         }
       }
       map.put(projectDirectory.getName, fhirMappingMap)

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mapping/ProjectMappingFolderRepository.scala
@@ -222,6 +222,9 @@ class ProjectMappingFolderRepository(mappingRepositoryFolderPath: String, projec
     }
     var directories = Seq.empty[File]
     directories = folder.listFiles.filter(_.isDirectory).toSeq
+    if (directories.isEmpty) {
+      throw new RuntimeException("There is no project folder for mapping in the repository")
+    }
     directories.foreach { projectDirectory =>
       // mapping-id -> FhirMapping
       val fhirMappingMap: mutable.Map[String, FhirMapping] = mutable.Map.empty

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mappingcontext/MappingContextFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mappingcontext/MappingContextFolderRepository.scala
@@ -1,6 +1,5 @@
 package io.tofhir.server.service.mappingcontext
 
-
 import akka.stream.scaladsl.FileIO
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
@@ -186,9 +185,6 @@ class MappingContextFolderRepository(mappingContextRepositoryFolderPath: String,
     }
     var directories = Seq.empty[File]
     directories = folder.listFiles.filter(_.isDirectory).toSeq
-    if (directories.isEmpty) {
-      throw new RuntimeException("There is no project folder for mapping-context in the repository")
-    }
     directories.foreach { projectDirectory =>
       val files = IOUtil.getFilesFromFolder(projectDirectory, withExtension = None, recursively = Some(true))
       val fileNameList = files.map(_.getName)

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/mappingcontext/MappingContextFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/mappingcontext/MappingContextFolderRepository.scala
@@ -1,5 +1,6 @@
 package io.tofhir.server.service.mappingcontext
 
+
 import akka.stream.scaladsl.FileIO
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
@@ -185,6 +186,9 @@ class MappingContextFolderRepository(mappingContextRepositoryFolderPath: String,
     }
     var directories = Seq.empty[File]
     directories = folder.listFiles.filter(_.isDirectory).toSeq
+    if (directories.isEmpty) {
+      throw new RuntimeException("There is no project folder for mapping-context in the repository")
+    }
     directories.foreach { projectDirectory =>
       val files = IOUtil.getFilesFromFolder(projectDirectory, withExtension = None, recursively = Some(true))
       val fileNameList = files.map(_.getName)

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/schema/SchemaFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/schema/SchemaFolderRepository.scala
@@ -282,6 +282,9 @@ class SchemaFolderRepository(schemaRepositoryFolderPath: String, projectFolderRe
     if (!folder.exists()) {
       folder.mkdirs()
     }
+    if(folder.listFiles().filter(_.isDirectory).toSeq.isEmpty){
+      throw new RuntimeException("There is no project folder for schema in the repository")
+    }
     folder.listFiles().foreach(projectFolder => {
       var files = Seq.empty[File]
       try {

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/schema/SchemaFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/schema/SchemaFolderRepository.scala
@@ -282,9 +282,6 @@ class SchemaFolderRepository(schemaRepositoryFolderPath: String, projectFolderRe
     if (!folder.exists()) {
       folder.mkdirs()
     }
-    if(folder.listFiles().filter(_.isDirectory).toSeq.isEmpty){
-      throw new RuntimeException("There is no project folder for schema in the repository")
-    }
     folder.listFiles().foreach(projectFolder => {
       var files = Seq.empty[File]
       try {


### PR DESCRIPTION
Each repository directory should include project directories. For example, for the mapping repository, we should have:

- mappings
  - project1
    - project1-mapping.json
  - project2
    - project2.-mapping.json
  
If there are some files instead of directories inside mappings folder, the initialization of tofhir-server fails. This MR handles such problems.
