### PR TITLE
Add custom error message for invalid or missing file format

### DIFF
--- a/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
@@ -1,6 +1,19 @@
 package io.tofhir.engine.model
 
 /**
+ * Custom exception class for signaling errors related to missing or invalid file formats.
+ *
+ * This exception is thrown when a required file format is not provided or is determined
+ * to be invalid during processing.
+ *
+ * @param message A descriptive message providing more information about the exception.
+ * @throws RuntimeException This exception extends the RuntimeException class for signaling runtime errors.
+ *
+ */
+class MissingFileFormatException(message: String) extends RuntimeException(message)
+
+
+/**
  * FHIR Mapping task instance
  * {@link mapping} will be executed if it is provided. Otherwise, the mapping referenced by {@link mappingRef} is
  * retrieved from the repository and executed.
@@ -25,12 +38,36 @@ trait FhirMappingSourceContext extends Serializable {
 /**
  * Context/configuration for one of the source of the mapping that will read the source data from file system
  *
- * @param path        File path to the source file  e.g. patients.csv
+ * @param path        File path to the source file or folder, e.g., "patients.csv" or "patients".
  * @param fileFormat  Format of the file (csv | json | parquet) if it can not be inferred from path e.g. csv
  * @param options     Further options for the format (Spark Data source options for the format e.g. For csv -> https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option)
  */
 case class FileSystemSource(path: String, fileFormat:Option[String] = None, options:Map[String, String] = Map.empty[String, String], override val preprocessSql: Option[String] = None) extends FhirMappingSourceContext {
-  def sourceType:String = fileFormat.getOrElse(path.split('.').last)
+  /**
+   * Determines the source type based on the file format and path.
+   *
+   * @return The determined source type.
+   * @throws MissingFileFormatException If the file format is missing or invalid.
+   */
+  def sourceType: String = {
+    // the determined format
+    var format = fileFormat
+    // split the path into segments based on the period ('.')
+    val pathSegments = path.split('.')
+
+    // if the file format is empty and there are exactly two segments in the path,
+    // set the file format based on the last segment of the path
+    if (format.isEmpty && pathSegments.length == 2) {
+      format = Some(pathSegments.last)
+    }
+
+    // if the file format is empty, throw an exception
+    if (format.isEmpty) {
+      throw new MissingFileFormatException("File format is missing for FileSystemSource. Please provide a valid file format.")
+    }
+    format.get
+  }
+
 }
 /**
  * Context/configuration for one of the source of the mapping that will read the source data from an SQL database

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
@@ -55,9 +55,9 @@ case class FileSystemSource(path: String, fileFormat:Option[String] = None, opti
     // split the path into segments based on the period ('.')
     val pathSegments = path.split('.')
 
-    // if the file format is empty and there are exactly two segments in the path,
+    // if the file format is empty and path is a file i.e. there are at least two segments in the path,
     // set the file format based on the last segment of the path
-    if (format.isEmpty && pathSegments.length == 2) {
+    if (format.isEmpty && pathSegments.length > 1) {
       format = Some(pathSegments.last)
     }
 


### PR DESCRIPTION
Defines a custom exception named MissingFileFormatException and improves FileSystemSource.sourceType function to make use of this custom exception.