### PR TITLE
Fix the bug which deletes the archived files

### DIFF
--- a/tofhir-engine/src/test/scala/io/tofhir/test/engine/execution/FileStreamInputArchiverTest.scala
+++ b/tofhir-engine/src/test/scala/io/tofhir/test/engine/execution/FileStreamInputArchiverTest.scala
@@ -81,6 +81,10 @@ class FileStreamInputArchiverTest extends AnyFlatSpec with Matchers {
     finalArchivePath.toFile.exists() shouldBe true
     testCsvFile.exists() shouldBe false
 
+    // Apply archiving using a new FileStreamInputArchiver to simulate the rerun of a streaming job
+    new FileStreamInputArchiver(runningJobRegistryMock).applyArchivingOnStreamingJob(testExecution, mappingUrl)
+    // Check whether archiving file still exists
+    finalArchivePath.toFile.exists() shouldBe true
     // Clean test directory
     org.apache.commons.io.FileUtils.deleteDirectory(new File(ToFhirConfig.sparkCheckpointDirectory))
     org.apache.commons.io.FileUtils.deleteDirectory(new File(ToFhirConfig.engineConfig.archiveFolder))


### PR DESCRIPTION
Let's assume that we run a streaming job which archives a file. When you rerun this job, the archived files are deleted from the archive folder. This MR fixes this problem and adds a test for this case.