### PR TITLE
Implement an endpoint to proxy requests to tofhir-redcap

### DIFF
--- a/tofhir-server/src/main/resources/application.conf
+++ b/tofhir-server/src/main/resources/application.conf
@@ -176,3 +176,18 @@ akka = {
     }
   }
 }
+
+# Configuration for the tofhir-redcap service
+tofhir-redcap {
+  # Base URL of the tofhir-redcap service
+  endpoint = "http://localhost:8095/tofhir-redcap"
+
+  # Paths for the endpoints provided by tofhir-redcap
+  paths {
+    # Specifies the path to the notification endpoint relative to the endpoint URL i.e. http://localhost:8095/tofhir-redcap/notification
+    notification = "notification"
+
+    # Specifies the path to the projects endpoint relative to the endpoint URL  i.e. http://localhost:8095/tofhir-redcap/projects
+    projects = "projects"
+  }
+}

--- a/tofhir-server/src/main/scala/io/tofhir/server/ToFhirServer.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/ToFhirServer.scala
@@ -1,7 +1,7 @@
 package io.tofhir.server
 
 import io.tofhir.engine.config.ToFhirConfig
-import io.tofhir.server.config.LogServiceConfig
+import io.tofhir.server.config.{LogServiceConfig, RedCapServiceConfig}
 import io.tofhir.server.common.config.WebServerConfig
 import io.tofhir.server.endpoint.ToFhirServerEndpoint
 import io.tofhir.server.fhir.FhirDefinitionsConfig
@@ -13,7 +13,8 @@ object ToFhirServer {
     val webServerConfig = new WebServerConfig(actorSystem.settings.config.getConfig("webserver"))
     val fhirDefinitionsConfig = new FhirDefinitionsConfig(actorSystem.settings.config.getConfig("fhir"))
     val logServiceConfig = new LogServiceConfig(actorSystem.settings.config.getConfig("log-service"))
-    val endpoint = new ToFhirServerEndpoint(ToFhirConfig.engineConfig, webServerConfig, fhirDefinitionsConfig, logServiceConfig)
+    val redCapServiceConfig = new RedCapServiceConfig(actorSystem.settings.config.getConfig("tofhir-redcap"))
+    val endpoint = new ToFhirServerEndpoint(ToFhirConfig.engineConfig, webServerConfig, fhirDefinitionsConfig, logServiceConfig, redCapServiceConfig)
 
     ToFhirHttpServer.start(endpoint.toFHIRRoute, webServerConfig)
   }

--- a/tofhir-server/src/main/scala/io/tofhir/server/config/RedCapServiceConfig.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/config/RedCapServiceConfig.scala
@@ -1,0 +1,37 @@
+package io.tofhir.server.config
+
+import com.typesafe.config.Config
+
+import scala.util.Try
+
+/**
+ * Configuration class for the tofhir-redcap.
+ *
+ * @param redCapServiceConfig The configuration object containing the settings for the tofhir-redcap service.
+ */
+class RedCapServiceConfig(redCapServiceConfig: Config) {
+  /**
+   * The path to the notification endpoint.
+   */
+  private lazy val notificationPath: String = Try(redCapServiceConfig.getString("paths.notification")).getOrElse("notification")
+
+  /**
+   * The path to the projects endpoint.
+   */
+  private lazy val projectsPath: String = Try(redCapServiceConfig.getString("paths.projects")).getOrElse("projects")
+
+  /**
+   * The base endpoint URL for the tofhir-redcap service.
+   */
+  private lazy val endpoint: String = Try(redCapServiceConfig.getString("endpoint")).getOrElse("http://localhost:8095/tofhir-redcap")
+
+  /**
+   * Constructs the full URL for the notification endpoint by combining the base endpoint URL and the notification path.
+   */
+  lazy val notificationEndpoint: String = s"$endpoint/$notificationPath"
+
+  /**
+   * Constructs the full URL for the projects endpoint by combining the base endpoint URL and the projects path.
+   */
+  lazy val projectsEndpoint: String = s"$endpoint/$projectsPath"
+}

--- a/tofhir-server/src/main/scala/io/tofhir/server/endpoint/RedCapEndpoint.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/endpoint/RedCapEndpoint.scala
@@ -1,0 +1,93 @@
+package io.tofhir.server.endpoint
+
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import com.typesafe.scalalogging.LazyLogging
+import io.tofhir.engine.Execution.actorSystem.dispatcher
+import io.tofhir.server.common.model.ToFhirRestCall
+import io.tofhir.server.config.RedCapServiceConfig
+import io.tofhir.server.endpoint.RedCapEndpoint.{SEGMENT_NOTIFICATION, SEGMENT_REDCAP}
+import io.tofhir.common.model.Json4sSupport._
+import io.tofhir.server.model.RedCapProjectConfig
+import io.tofhir.server.service.RedCapService
+
+/**
+ * This class defines routes for handling requests related to tofhir-redcap service.
+ *
+ * @param redCapServiceConfig The configuration object for the tofhir-redcap service.
+ */
+class RedCapEndpoint(redCapServiceConfig: RedCapServiceConfig) extends LazyLogging {
+
+  // Create an instance of RedCapService using the provided configuration
+  val service: RedCapService = new RedCapService(redCapServiceConfig: RedCapServiceConfig)
+
+  /**
+   * Defines the routes for handling requests to the tofhir-redcap service.
+   *
+   * @param request The incoming REST call request.
+   * @return A Route representing the defined routes for the RedCap endpoint.
+   */
+  def route(request: ToFhirRestCall): Route = {
+    pathPrefix(SEGMENT_REDCAP) {
+      pathEndOrSingleSlash { // Operations on Redcap projects
+        getProjects ~ saveProjects
+      } ~ pathPrefix(SEGMENT_NOTIFICATION) {
+        pathEndOrSingleSlash { // Operations on Redcap notification url
+          getNotificationUrl
+        }
+      }
+    }
+  }
+
+  /**
+   * Retrieves the notification URL.
+   *
+   * @return A Route representing the route to retrieve the notification URL.
+   */
+  private def getNotificationUrl: Route = {
+    get {
+      complete {
+        service.getNotificationUrl.map { notificationUrl =>
+          HttpResponse(StatusCodes.OK, entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, notificationUrl))
+        }
+      }
+    }
+  }
+
+  /**
+   * Saves RedCap projects.
+   *
+   * @return A Route representing the route to save RedCap projects.
+   */
+  private def saveProjects: Route = {
+    post {
+      entity(as[Seq[RedCapProjectConfig]]) { projects =>
+        complete {
+          service.saveProjects(projects)
+        }
+      }
+    }
+  }
+
+  /**
+   * Retrieves RedCap projects.
+   *
+   * @return A Route representing the route to retrieve RedCap projects.
+   */
+  private def getProjects: Route = {
+    get {
+      complete {
+        service.getProjects
+      }
+    }
+  }
+}
+
+/**
+ * Contains constants for segment names used in the RedCap endpoint.
+ */
+object RedCapEndpoint {
+  val SEGMENT_REDCAP = "redcap"
+  val SEGMENT_NOTIFICATION = "notification"
+}

--- a/tofhir-server/src/main/scala/io/tofhir/server/model/RedCapProjectConfig.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/model/RedCapProjectConfig.scala
@@ -1,0 +1,6 @@
+package io.tofhir.server.model
+
+/**
+ * Configuration of a REDCap project
+ * */
+case class RedCapProjectConfig(id: String, token: String)

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/RedCapService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/RedCapService.scala
@@ -1,0 +1,87 @@
+package io.tofhir.server.service
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest}
+import com.typesafe.scalalogging.LazyLogging
+import io.tofhir.engine.Execution.actorSystem
+import io.tofhir.engine.util.FhirMappingJobFormatter.formats
+import io.tofhir.server.config.RedCapServiceConfig
+import io.tofhir.server.model.RedCapProjectConfig
+import org.json4s.DefaultFormats
+import org.json4s.jackson.{JsonMethods, Serialization}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+/**
+ * Class for interacting with the tofhir-redcap service.
+ *
+ * This class provides methods to retrieve notification URLs, save projects, and get projects from the tofhir-redcap service.
+ *
+ * @param redCapServiceConfig The configuration object for the tofhir-redcap service.
+ */
+class RedCapService(redCapServiceConfig: RedCapServiceConfig) extends LazyLogging {
+
+  // Timeout duration for proxy requests to the tofhir-redcap service
+  private val timeout: FiniteDuration = 20.seconds
+
+  /**
+   * Retrieves the notification URL from the tofhir-redcap service.
+   *
+   * @return A Future containing the notification URL as a String.
+   */
+  def getNotificationUrl: Future[String] = {
+    val proxiedRequest = HttpRequest(
+      method = HttpMethods.GET,
+      uri = s"${redCapServiceConfig.notificationEndpoint}",
+      headers = RawHeader("Content-Type", "application/json") :: Nil
+    )
+
+    // Add timeout and transform response to a String
+    Http().singleRequest(proxiedRequest)
+      .flatMap { resp => resp.entity.toStrict(timeout) }
+      .map(strictEntity => strictEntity.data.utf8String)
+  }
+
+  /**
+   * Saves the provided RedCap project configurations to the tofhir-redcap service.
+   *
+   * @param requestBody The sequence of RedCapProjectConfig objects to be saved.
+   * @return A Future representing the completion of the save operation.
+   */
+  def saveProjects(requestBody: Seq[RedCapProjectConfig]): Future[Unit] = {
+    implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+    val proxiedRequest = HttpRequest(
+      method = HttpMethods.POST,
+      uri = s"${redCapServiceConfig.projectsEndpoint}",
+      headers = RawHeader("Content-Type", "application/json") :: Nil,
+      entity = HttpEntity(ContentTypes.`application/json`, Serialization.write(requestBody))
+    )
+
+    // Add timeout
+    Http().singleRequest(proxiedRequest)
+      .flatMap { resp => resp.entity.toStrict(timeout) }
+      .map(_ => ())
+  }
+
+  /**
+   * Retrieves the projects from the tofhir-redcap service.
+   *
+   * @return A Future containing the sequence of RedCapProjectConfig objects retrieved from the service.
+   */
+  def getProjects: Future[Seq[RedCapProjectConfig]] = {
+    val proxiedRequest = HttpRequest(
+      method = HttpMethods.GET,
+      uri = s"${redCapServiceConfig.projectsEndpoint}",
+      headers = RawHeader("Content-Type", "application/json") :: Nil
+    )
+
+    // Add timeout and transform response to a sequence of RedCapProjectConfig objects
+    Http().singleRequest(proxiedRequest)
+      .flatMap { resp => resp.entity.toStrict(timeout) }
+      .map(strictEntity => JsonMethods.parse(strictEntity.data.utf8String).extract[Seq[RedCapProjectConfig]])
+  }
+}

--- a/tofhir-server/src/test/resources/application.conf
+++ b/tofhir-server/src/test/resources/application.conf
@@ -109,3 +109,18 @@ fhir = {
   # Path to the zip file or folder that includes the FHIR Code system definitions (FHIR CodeSystem) that are referenced by your FHIR value sets.
   codesystems-path = "codesystems"
 }
+
+# Configuration for the tofhir-redcap service
+tofhir-redcap {
+  # Base URL of the tofhir-redcap service
+  endpoint = "http://localhost:8095/tofhir-redcap"
+
+  # Paths for the endpoints provided by tofhir-redcap
+  paths {
+    # Specifies the path to the notification endpoint relative to the endpoint URL i.e. http://localhost:8095/tofhir-redcap/notification
+    notification = "notification"
+
+    # Specifies the path to the projects endpoint relative to the endpoint URL  i.e. http://localhost:8095/tofhir-redcap/projects
+    projects = "projects"
+  }
+}

--- a/tofhir-server/src/test/scala/io/tofhir/server/BaseEndpointTest.scala
+++ b/tofhir-server/src/test/scala/io/tofhir/server/BaseEndpointTest.scala
@@ -8,7 +8,7 @@ import io.tofhir.common.model.Json4sSupport.formats
 import io.tofhir.engine.config.ToFhirEngineConfig
 import io.tofhir.engine.util.FhirMappingJobFormatter.EnvironmentVariable
 import io.tofhir.engine.util.FileUtils
-import io.tofhir.server.config.LogServiceConfig
+import io.tofhir.server.config.{LogServiceConfig, RedCapServiceConfig}
 import io.tofhir.server.common.config.WebServerConfig
 import io.tofhir.server.endpoint.ToFhirServerEndpoint
 import io.tofhir.server.fhir.FhirDefinitionsConfig
@@ -33,6 +33,7 @@ trait BaseEndpointTest extends AnyWordSpec with Matchers with ScalatestRouteTest
   val webServerConfig = new WebServerConfig(system.settings.config.getConfig("webserver"))
   val fhirDefinitionsConfig = new FhirDefinitionsConfig(system.settings.config.getConfig("fhir"))
   val logServiceConfig = new LogServiceConfig(system.settings.config.getConfig("log-service"))
+  val redCapServiceConfig = new RedCapServiceConfig(system.settings.config.getConfig("tofhir-redcap"))
   // route endpoint
   var route: Route = _
 
@@ -81,7 +82,7 @@ trait BaseEndpointTest extends AnyWordSpec with Matchers with ScalatestRouteTest
     FileUtils.getPath(fhirDefinitionsConfig.codesystemsPath.get).toFile.mkdirs()
     FileUtils.getPath(fhirDefinitionsConfig.valuesetsPath.get).toFile.mkdirs()
     // initialize endpoint and route
-    val endpoint = new ToFhirServerEndpoint(toFhirEngineConfig, webServerConfig, fhirDefinitionsConfig, logServiceConfig)
+    val endpoint = new ToFhirServerEndpoint(toFhirEngineConfig, webServerConfig, fhirDefinitionsConfig, logServiceConfig, redCapServiceConfig)
     route = endpoint.toFHIRRoute
   }
 


### PR DESCRIPTION
This merge request adds a new endpoint, enabling the proxying of requests to the tofhir-redcap microservice.