### PR TITLE
Validate the Fhir Repository url before executing the mapping job

### DIFF
--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/write/BaseFhirWriter.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/write/BaseFhirWriter.scala
@@ -16,6 +16,12 @@ abstract class BaseFhirWriter(sinkSettings: FhirSinkSettings) extends Serializab
    * @param df
    */
   def write(sparkSession: SparkSession, df: Dataset[FhirMappingResult], problemsAccumulator: CollectionAccumulator[FhirMappingResult]): Unit
+
+  /**
+   * Validates the current FHIR writer. This method should be implemented by concrete subclasses to perform any necessary validation checks.
+   * If the validation fails, an exception should be thrown.
+   */
+  def validate(): Unit
 }
 
 /**

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/write/FileSystemWriter.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/write/FileSystemWriter.scala
@@ -31,6 +31,13 @@ class FileSystemWriter(sinkSettings: FileSystemSinkSettings) extends BaseFhirWri
         throw new NotImplementedError()
     }
   }
+
+  /**
+   * Validates the current FHIR writer.
+   *
+   * For the FileSystemWriter, validation is not implemented and this method does nothing.
+   */
+  override def validate(): Unit = {}
 }
 
 object FileSystemWriter {

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/execution/RunningJobRegistry.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/execution/RunningJobRegistry.scala
@@ -89,6 +89,10 @@ class RunningJobRegistry(spark: SparkSession) {
   //  To resolve this issue, we need to assign a unique Spark job group id at the start of mapping job execution, before registering it with the RunningJobRegistry.
   //  We should call setJobGroup function before Spark tasks begin execution. The ideal location for this call seems to be the readSourceExecuteAndWriteInBatches function,
   //  although thorough testing is required to ensure its effectiveness.
+  //  UPDATE: Although I set the job group id of each thread to the same value, cancelJobGroup does not work as expected
+  //  because it only cancels the active jobs in Spark 3.5 not the future submitted jobs.
+  //  In the main branch of Spark, this method can take a parameter named cancelFutureJobs that can resolve our problem.
+  //  Please see https://github.com/apache/spark/blob/33a153a6bbcba0d9b2ab20404c7d3b6db86d7b4a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L1108
   /**
    * Caches a batch job. This method sets the Spark job group id for further referencing (e.g. cancelling the Spark jobs via the job group).
    * Spark job group manages job groups per different threads. This practically means that for each mapping execution request initiated by a REST call would have a different job group.

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/mapping/FhirMappingJobManager.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/mapping/FhirMappingJobManager.scala
@@ -58,6 +58,7 @@ class FhirMappingJobManager(
                                  identityServiceSettings: Option[IdentityServiceSettings] = None,
                                  timeRange: Option[(LocalDateTime, LocalDateTime)] = None): Future[Unit] = {
     val fhirWriter = FhirWriterFactory.apply(sinkSettings)
+    fhirWriter.validate()
     mappingJobExecution.mappingTasks.foldLeft(Future((): Unit)) { (f, task) => // Initial empty Future
       f.flatMap { _ => // Execute the Futures in the Sequence consecutively (not in parallel)
         val jobResult = FhirMappingJobResult(mappingJobExecution, Some(task.mappingRef))
@@ -109,6 +110,7 @@ class FhirMappingJobManager(
                                      identityServiceSettings: Option[IdentityServiceSettings] = None,
                                     ): Map[String, Future[StreamingQuery]] = {
     val fhirWriter = FhirWriterFactory.apply(sinkSettings)
+    fhirWriter.validate()
     mappingJobExecution.mappingTasks
       .map(t => {
         logger.debug(s"Streaming mapping job ${mappingJobExecution.job.id}, mapping url ${t.mappingRef} is started and waiting for the data...")
@@ -246,6 +248,7 @@ class FhirMappingJobManager(
                                   identityServiceSettings: Option[IdentityServiceSettings] = None,
                                  ): Future[Unit] = {
     val fhirWriter = FhirWriterFactory.apply(sinkSettings)
+    fhirWriter.validate()
 
     readSourceAndExecuteTask(mappingJobExecution.job.id, mappingJobExecution.mappingTasks.head, sourceSettings, terminologyServiceSettings, identityServiceSettings, executionId = Some(mappingJobExecution.id))
       .map {

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/model/InvalidFhirRepositoryUrlException.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/model/InvalidFhirRepositoryUrlException.scala
@@ -1,0 +1,11 @@
+package io.tofhir.engine.model
+
+/**
+ * Exception thrown when attempting to use a URL that does not point to a valid FHIR repository.
+ *
+ * @param reason A description of the reason for the exception.
+ * @param cause  The cause of this exception, if any.
+ */
+final case class InvalidFhirRepositoryUrlException(private val reason: String, private val cause: Throwable = None.orNull)
+  extends Exception(reason: String, cause: Throwable) {
+}


### PR DESCRIPTION
Extend BaseFhirWriter class with a validate method and implement FhirRepositoryWriter.validate method to check whether the given FHIR Repository URL points to a valid FHIR Repository or not.