### PR TITLE
Reduce the memory usage of local terminology service

### DIFF
--- a/docker/server/docker-entrypoint.sh
+++ b/docker/server/docker-entrypoint.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
-JAVA_CMD="java -Xms256m -Xmx3g -jar "
+# Set default Java options
+DEFAULT_JAVA_OPTIONS="-Xms256m -Xmx3g"
+
+# Use environment variable if provided, otherwise use default value
+JAVA_OPTIONS="${JAVA_OPTIONS:-$DEFAULT_JAVA_OPTIONS}"
+
+# Construct JAVA_CMD with Java options
+JAVA_CMD="java $JAVA_OPTIONS -jar "
 
 # Configure application.conf path
 if [ ! -z "$APP_CONF_FILE" ]; then


### PR DESCRIPTION
- Enhance CsvUtil.readFromCSV to read rows iteratively from CSV file, minimizing memory usage. Results in an average reduction of 0.1 GB in memory consumption.
- Trigger Garbage Collection in LocalTerminologyService immediately after populating concept maps and code systems to reduce memory usage by 0.5 GB on average.
- Eliminate "lazy" keyword from FhirMappingService.terminologyService variable to ensure creation of Local Terminology Service only once, preventing multiple creations caused by the "lazy" keyword.