### PR TITLE
Extend FhirMappingJobManager and update file reading logic for batch jobs

### DIFF
--- a/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/FileDataSourceReader.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/data/read/FileDataSourceReader.scala
@@ -92,7 +92,8 @@ class FileDataSourceReader(spark: SparkSession) extends BaseDataSourceReader[Fil
               .options(otherOptions)
               .schema(csvSchema.orNull)
               .csv(finalPath)
-        case SourceFileFormats.JSON =>
+        // assume that each line in the txt files contains a separate JSON object.
+        case SourceFileFormats.JSON | SourceFileFormats.TXT=>
           if(sourceSettings.asStream)
             spark.readStream.options(mappingSource.options).schema(schema.orNull).json(finalPath)
               // add a dummy column called 'filename' to print a log when the data reading is started for a file

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/mapping/IFhirMappingJobManager.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/mapping/IFhirMappingJobManager.scala
@@ -3,6 +3,7 @@ package io.tofhir.engine.mapping
 import java.time.LocalDateTime
 
 import io.tofhir.engine.model._
+import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.streaming.StreamingQuery
 
 import scala.concurrent.Future
@@ -97,4 +98,22 @@ trait IFhirMappingJobManager {
                                   terminologyServiceSettings: Option[TerminologyServiceSettings] = None,
                                   identityServiceSettings: Option[IdentityServiceSettings] = None
                                  ): Future[Seq[FhirMappingResult]]
+
+  /**
+   * Executes the specified FHIR mapping job and returns the resulting FhirMappingResult dataset.
+   *
+   * @param mappingJobExecution        The FHIR Mapping Job execution details.
+   * @param sourceSettings             A map containing settings for the source system(s).
+   * @param terminologyServiceSettings Optional settings for the terminology service to use within mappings (e.g., for lookupDisplay).
+   * @param identityServiceSettings    Optional settings for the identity service to use within mappings (e.g., for resolveIdentifier).
+   * @param taskCompletionCallback     A callback function to be invoked when a mapping task execution is completed.
+   * @return A Future containing a Dataset of FhirMappingResult representing the outcome of the mapping job.
+   */
+  def executeMappingJobAndReturn(mappingJobExecution: FhirMappingJobExecution,
+                                 sourceSettings: Map[String, DataSourceSettings],
+                                 terminologyServiceSettings: Option[TerminologyServiceSettings] = None,
+                                 identityServiceSettings: Option[IdentityServiceSettings] = None,
+                                 taskCompletionCallback: () => Unit
+                                ): Future[Dataset[FhirMappingResult]]
+
 }

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingJobExecution.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingJobExecution.scala
@@ -17,6 +17,8 @@ import java.util.regex.Pattern
  * @param mappingTasks               List of mapping tasks to be executed (as a subset of the mapping tasks defined in the job)
  * @param jobGroupIdOrStreamingQuery Keeps Spark job group id for batch jobs and StreamingQuery for streaming jobs
  */
+// TODO: The FhirMappingJobExecution model currently includes the entire FhirMappingJob ('job' field), which is unnecessary.
+//  We should remove the 'job' field from the model. Instead, add only the necessary fields to the model.
 case class FhirMappingJobExecution(id: String = UUID.randomUUID().toString,
                                    projectId: String = "",
                                    job: FhirMappingJob,

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
@@ -38,21 +38,22 @@ trait FhirMappingSourceContext extends Serializable {
 /**
  * Context/configuration for one of the sources of the mapping that will read the source data from the file system.
  *
- * For batch jobs, you should either provide a file name in the "path" field with a file extension or provide the file name
- * without an extension in the "path" field and indicate the extension in the "fileFormat" field.
+ * For batch jobs, you should either provide a file name in the "path" field with a file extension or provide the folder name
+ * in the "path" field and indicate the extension in the "fileFormat" field. In the latter case, it reads the files with
+ * the specified file format in the given folder.
  *
- * Examples:
+ * Examples for Batch Jobs:
  *   - With extension in path:
- *     FileSystemSource(path = "data/patients.csv") => Will read "data/patients.csv" file
- *   - Without extension in path (specifying file format separately):
- *     FileSystemSource(path = "data/patients", fileFormat = Some("csv")) => Will read "data/patients.csv" file
+ *     FileSystemSource(path = "data/patients.csv") => Will read the "data/patients.csv" file.
+ *   - Providing folder name and file format:
+ *     FileSystemSource(path = "data/patients", fileFormat = Some("csv")) => Will read all "csv" files in the "data/patients" folder.
  *
  * For streaming jobs, you should provide a folder name in the "path" field and a file format in the "fileFormat" field so that
- * it can read the files with specified file formats in the given folder.
+ * it can read the files with the specified file format in the given folder.
  *
- * Examples:
+ * Examples for Streaming Jobs:
  *   - Providing folder name and file format:
- *     FileSystemSource(path = "data/streaming/patients", fileFormat = Some("json")) => Will read "json" files in "data/streaming/patients" folder
+ *     FileSystemSource(path = "data/streaming/patients", fileFormat = Some("json")) => Will read all "json" files in the "data/streaming/patients" folder.
  * @param path        File path to the source file or folder, e.g., "patients.csv" or "patients".
  * @param fileFormat  Format of the file (csv | json | parquet) if it cannot be inferred from the path, e.g., csv.
  * @param options     Further options for the format (Spark Data source options for the format, e.g., for csv -> https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option).

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
@@ -126,5 +126,6 @@ object SourceFileFormats {
   final val PARQUET = "parquet"
   final val JSON = "json"
   final val AVRO = "avro"
+  final val TXT = "txt"
 }
 


### PR DESCRIPTION
- Included a TODO on the `FhirMappingJobExecution` model
- Added a new function `executeMappingJobAndReturn` to the `FhirMappingJobManager` class
- Enhanced the documentation for the `FileSystemSource` model.
- Updated the `FileDataSourceReader` to support reading from .txt files.
- Updated the `FileDataSourceReader` to read all files in a specified directory for batch jobs based on provided "path" and "fileFormat". Previously, it concatenated "path" and "fileFormat" to read a single file. For example, `FileSystemSource(path = "data/patients", fileFormat = Some("csv"))` used to read `data/patients.csv`, but now it reads all csv files within the `data/patients` directory.