### PR TITLE
Set timeout to 1 second to fetch redcap version

### DIFF
--- a/tofhir-server/src/main/scala/io/tofhir/server/model/Metadata.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/model/Metadata.scala
@@ -3,15 +3,15 @@ package io.tofhir.server.model
 /**
  * Model that represents the metadata of the server.
  *
- * @param name                The name of the server.
- * @param description         A description of the server.
- * @param version             The current version of the server.
- * @param majorFhirVersion    The major FHIR version of definitions (profiles, valuesets, codesystems) supported by the server.
- * @param toFhirRedcapVersion The optional toFHIR-Redcap server version.
- * @param definitionsRootUrls Optional list of root URLs for definitions.
- * @param schemasFhirVersion  The FHIR version used for schemas.
- * @param repositoryNames     The configured repository names.
- * @param archiving           The archiving configuration.
+ * @param name                   The name of the server.
+ * @param description            A description of the server.
+ * @param version                The current version of the server.
+ * @param fhirDefinitionsVersion The major FHIR version of definitions (profiles, valuesets, codesystems) supported by the server.
+ * @param toFhirRedcapVersion    The optional toFHIR-Redcap server version.
+ * @param definitionsRootUrls    Optional list of root URLs for definitions.
+ * @param schemasFhirVersion     The FHIR version used for schemas.
+ * @param repositoryNames        The configured repository names.
+ * @param archiving              The archiving configuration.
  */
 case class Metadata(name: String,
                     description: String,

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/MetadataService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/MetadataService.scala
@@ -75,7 +75,7 @@ class MetadataService(toFhirEngineConfig: ToFhirEngineConfig,
     val responseFuture: Future[HttpResponse] = Http().singleRequest(proxiedRequest)
     val responseAsString = Try(Await.result(
       responseFuture.flatMap(resp => Unmarshal(resp.entity).to[String]),
-      10.seconds
+      1.seconds // increasing this leads to increase initial loading time of the toFHIR frontend
     ))
 
     responseAsString match {


### PR DESCRIPTION
… this leads to increase the initial loading time of toFHIR app if redcap service is not available