### PR TITLE
Extend FhirMappingTask model with a reference to the source name

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,19 +829,19 @@ We'll implement a mapping job that utilizes these two CSV files as data sources 
 
 ##### 1. Define Source Settings
 
-First, define the source settings pointing to the two different file data sources:
+First, define the source settings pointing to the two different data sources:
 
 ```json
 {
   "sourceSettings" : {
-    "patient" : {
+    "patientSource" : {
       "jsonClass" : "FileSystemSourceSettings",
       "name" : "patient-test-data",
       "sourceUri" : "http://test-data",
       "dataFolderPath" : "/test-data",
       "asStream" : false
     },
-    "patientGender" : {
+    "genderSource" : {
       "jsonClass" : "SqlSourceSettings",
       "name" : "patient-gender-test-data",
       "sourceUri" : "http://test-data-gender",
@@ -853,22 +853,22 @@ First, define the source settings pointing to the two different file data source
 }
 
 ```
-The `patient` source points to the `test-data` directory in the file system, while the `patientGender` source points to a relational
+The `patientSource` points to the `test-data` directory in the file system, while the `genderSource` points to a relational
 database, actually a query result or a table name. It is important to note that the mapping definitions are not directly connected to
-the data sources. `patientGender` source can point to a folder which means that the same mapping can be executed on the 
+the data sources. `genderSource` can point to a folder which means that the same mapping can be executed on the 
 data read from different sources. 
 
 ```json
 {
   "sourceSettings" : {
-    "patient" : {
+    "patientSource" : {
       "jsonClass" : "FileSystemSourceSettings",
       "name" : "patient-test-data",
       "sourceUri" : "http://test-data",
       "dataFolderPath" : "/test-data",
       "asStream" : false
     },
-    "patientGender" : {
+    "genderSource" : {
       "jsonClass" : "FileSystemSourceSettings",
       "name" : "patient-gender-test-data",
       "sourceUri" : "http://test-data-gender",
@@ -891,21 +891,27 @@ Next, specify the source contexts for your mappings in the job. Here's an exampl
         "jsonClass" : "FileSystemSource",
         "path" : "patient-simple.csv",
         "fileFormat" : "csv",
-        "options" : { }
+        "options" : { },
+        "sourceRef": "patientSource"
       },
       "patientGender" : {
         "jsonClass" : "SqlSource",
-        "query" : "SELECT pid, gender FROM patient_gender"
+        "query" : "SELECT pid, gender FROM patient_gender",
+        "sourceRef": "genderSource"
       }
     }
   } ]
 }
 ```
-In this example, `patient-simple.csv` is used for the `patient` source, while an SQL query result is used for the `patientGender` source. 
-Ensure that the keys in the `sourceContext` match those in the `sourceSettings` above! 
-Otherwise, if there is no match, the `sourceContext` will use first source specified in `sourceSettings`.
+In this example, `patient-simple.csv` is used for the `patient` mapping source, while an SQL query result is used for the `patientGender` mapping source. 
+Since the mapping job has more than one data source, we should specify the source reference in the mapping source context using `sourceRef` field.
+Here, `patient` source reads the csv file from `patientSource` whereas `patientGender` source reads the result of an SQL query from
+`genderSource`.
 
-If the `patientGender` was connected to file system in the job definition, the `sourceContext` parameters would be as in the following:
+If `sourceRef` is skipped or does not match any entry in the `sourceSettings`, the first source specified in `sourceSettings` will be used to
+read the data.
+
+If the `genderSource` was connected to file system in the job definition, the `sourceContext` parameters would be as in the following:
 ```json
 {
   "mappings" : [ {
@@ -915,13 +921,15 @@ If the `patientGender` was connected to file system in the job definition, the `
         "jsonClass" : "FileSystemSource",
         "path" : "patient-simple.csv",
         "fileFormat" : "csv",
-        "options" : { }
+        "options" : { },
+        "sourceRef": "patientSource"
       },
       "patientGender" : {
         "jsonClass" : "FileSystemSource",
         "path" : "patient-gender-simple.csv",
         "fileFormat" : "csv",
-        "options" : { }
+        "options" : { },
+        "sourceRef": "genderSource"
       }
     }
   } ]

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/model/FhirMappingTask.scala
@@ -33,6 +33,13 @@ trait FhirMappingSourceContext extends Serializable {
    * SQL Query to preprocess the source data
    */
   val preprocessSql: Option[String] = None
+  /**
+   * Reference to the source specified in the sourceSettings of a mapping job.
+   * This optional field can be used to explicitly link a source context to a particular source setting.
+   * If not provided, the source alias from the mapping will be used to determine the source settings,
+   * ensuring backward compatibility.
+   */
+  val sourceRef: Option[String] = None
 }
 
 /**
@@ -58,7 +65,7 @@ trait FhirMappingSourceContext extends Serializable {
  * @param fileFormat  Format of the file (csv | json | parquet) if it cannot be inferred from the path, e.g., csv.
  * @param options     Further options for the format (Spark Data source options for the format, e.g., for csv -> https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option).
  */
-case class FileSystemSource(path: String, fileFormat:Option[String] = None, options:Map[String, String] = Map.empty[String, String], override val preprocessSql: Option[String] = None) extends FhirMappingSourceContext {
+case class FileSystemSource(path: String, fileFormat:Option[String] = None, options:Map[String, String] = Map.empty[String, String], override val preprocessSql: Option[String] = None, override val sourceRef: Option[String] = None) extends FhirMappingSourceContext {
   /**
    * Infers the file format based on the provided path and file format.
    *
@@ -98,7 +105,7 @@ case class FileSystemSource(path: String, fileFormat:Option[String] = None, opti
  * @param query     Query to execute in the database
  * @param options   Further options for SQL source (Spark SQL Guide -> https://spark.apache.org/docs/3.4.1/sql-data-sources-jdbc.html ).
  */
-case class SqlSource(tableName: Option[String] = None, query: Option[String] = None, options:Map[String, String] = Map.empty[String, String], override val preprocessSql: Option[String] = None) extends FhirMappingSourceContext
+case class SqlSource(tableName: Option[String] = None, query: Option[String] = None, options:Map[String, String] = Map.empty[String, String], override val preprocessSql: Option[String] = None, override val sourceRef: Option[String] = None) extends FhirMappingSourceContext
 
 /**
  * Context/configuration for one of the source of the mapping that will read the source data from a kafka as stream
@@ -108,7 +115,7 @@ case class SqlSource(tableName: Option[String] = None, query: Option[String] = N
  * @param startingOffsets The start point when a query is started
  * @param options         Further options for Kafka source (Spark Kafka Guide -> https://spark.apache.org/docs/3.4.1/structured-streaming-kafka-integration.html)
  */
-case class KafkaSource(topicName: String, groupId: String, startingOffsets: String, options:Map[String, String] = Map.empty[String, String], override val preprocessSql: Option[String] = None) extends FhirMappingSourceContext
+case class KafkaSource(topicName: String, groupId: String, startingOffsets: String, options:Map[String, String] = Map.empty[String, String], override val preprocessSql: Option[String] = None, override val sourceRef: Option[String] = None) extends FhirMappingSourceContext
 
 /**
  * Represents a mapping source context for FHIR server data.
@@ -117,7 +124,7 @@ case class KafkaSource(topicName: String, groupId: String, startingOffsets: Stri
  * @param query          An optional query string to filter the FHIR resources.
  * @param preprocessSql  An optional SQL string for preprocessing the data before mapping.
  */
-case class FhirServerSource(resourceType: String, query: Option[String] = None, override val preprocessSql: Option[String] = None) extends FhirMappingSourceContext
+case class FhirServerSource(resourceType: String, query: Option[String] = None, override val preprocessSql: Option[String] = None, override val sourceRef: Option[String] = None) extends FhirMappingSourceContext
 
 /**
  * List of source file formats supported by tofhir

--- a/tofhir-engine/src/test/resources/patient-mapping-job-with-two-sources.json
+++ b/tofhir-engine/src/test/resources/patient-mapping-job-with-two-sources.json
@@ -1,14 +1,14 @@
 {
   "name" : "patient-job-test",
   "sourceSettings" : {
-	"patient" : {
+	"patientSource" : {
 	  "jsonClass" : "FileSystemSourceSettings",
 	  "name" : "patient-test-data",
 	  "sourceUri" : "http://test-data",
 	  "dataFolderPath" : "./test-data",
 	  "asStream" : false
 	},
-	"patientGender" : {
+	"genderSource" : {
 	  "jsonClass" : "FileSystemSourceSettings",
 	  "name" : "patient-gender-test-data",
 	  "sourceUri" : "http://test-data",
@@ -28,13 +28,15 @@
 		"jsonClass" : "FileSystemSource",
 		"path" : "patient-simple.csv",
 		"fileFormat" : "csv",
-		"options" : { }
+		"options" : { },
+		"sourceRef": "patientSource"
 	  },
 	  "patientGender" : {
 		"jsonClass" : "FileSystemSource",
 		"path" : "patient-gender-simple.csv",
 		"fileFormat" : "csv",
-		"options" : { }
+		"options" : { },
+		"sourceRef": "genderSource"
 	  }
 	}
   } ],


### PR DESCRIPTION
The mapping definition includes a field named **source** that lists the source schemas, each annotated with an alias such as "patient," "encounter," or "source."

When using this mapping in a mapping job, you must configure the **sourceSettings** field and the **sourceContext** in mappings[X].sourceContext to align with these mapping aliases.

This merge request introduces a **sourceRef** field to FhirMappingTask, reducing the strong dependency on mapping aliases. With this change, you don't need to modify the source settings of your mapping job when updating mapping aliases.

An example can be found in **_tofhir-engine/src/test/resources/patient-mapping-job-with-two-sources.json_**, and more details are available in the README file.

**Migration Scripts**
- The definition of mapping jobs should be updated as follows: For each source in `mappings[x].sourceContext`, add a `"sourceRef"` field. This field should reference the corresponding key in the `sourceSettings` configuration of the mapping job.