### PR TITLE
Implement base FHIR profile retrieval and CSV writing in addition to the improved documentation of handleJoin

### DIFF
--- a/tofhir-engine/src/test/resources/fhir-resources/encounter-summary-mapping-resource.json
+++ b/tofhir-engine/src/test/resources/fhir-resources/encounter-summary-mapping-resource.json
@@ -1,0 +1,356 @@
+[
+  {
+	"resourceType": "Patient",
+	"id": "example",
+	"text": {
+	  "status": "generated",
+	  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Peter James Chalmers</div>"
+	},
+	"identifier": [
+	  {
+		"use": "usual",
+		"type": {
+		  "coding": [
+			{
+			  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+			  "code": "MR",
+			  "display": "Medical Record Number"
+			}
+		  ]
+		},
+		"system": "http://hospital.smarthealthit.org",
+		"value": "12345"
+	  }
+	],
+	"active": true,
+	"name": [
+	  {
+		"use": "official",
+		"family": "Chalmers",
+		"given": [
+		  "Peter",
+		  "James"
+		]
+	  },
+	  {
+		"use": "usual",
+		"given": [
+		  "Jim"
+		]
+	  }
+	],
+	"telecom": [
+	  {
+		"system": "phone",
+		"value": "(03) 5555 6473",
+		"use": "work"
+	  }
+	],
+	"gender": "male",
+	"birthDate": "1974-12-25",
+	"deceasedBoolean": false,
+	"address": [
+	  {
+		"use": "home",
+		"type": "both",
+		"line": [
+		  "534 Erewhon St"
+		],
+		"city": "PleasantVille",
+		"district": "Rainbow",
+		"state": "Vic",
+		"postalCode": "3999",
+		"country": "Australia"
+	  }
+	],
+	"contact": [
+	  {
+		"relationship": [
+		  {
+			"coding": [
+			  {
+				"system": "http://terminology.hl7.org/CodeSystem/v2-0131",
+				"code": "N",
+				"display": "Next of Kin"
+			  }
+			]
+		  }
+		],
+		"name": {
+		  "family": "du Marché",
+		  "given": [
+			"Bénédicte"
+		  ]
+		},
+		"telecom": [
+		  {
+			"system": "phone",
+			"value": "+33 (237) 998327"
+		  }
+		],
+		"address": {
+		  "use": "home",
+		  "type": "both",
+		  "line": [
+			"534 Erewhon St"
+		  ],
+		  "city": "PleasantVille",
+		  "district": "Rainbow",
+		  "state": "Vic",
+		  "postalCode": "3999",
+		  "country": "Australia"
+		},
+		"gender": "female",
+		"period": {
+		  "start": "2012-01-01"
+		}
+	  }
+	],
+	"managingOrganization": {
+	  "reference": "Organization/1",
+	  "display": "Example Organization"
+	}
+  },
+  {
+	"resourceType": "Encounter",
+	"id": "example-encounter",
+	"status": "completed",
+	"class": [
+	  {
+		"coding": [
+		  {
+			"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+			"code": "AMB",
+			"display": "ambulatory"
+		  }
+		]
+	  }
+	],
+	"subject": {
+	  "reference": "Patient/example",
+	  "display": "Peter James Chalmers"
+	},
+	"plannedStartDate": "2024-07-22T08:00:00Z",
+	"plannedEndDate": "2024-07-22T09:00:00Z",
+	"serviceProvider": {
+	  "reference": "Organization/example-org",
+	  "display": "Example Organization"
+	}
+  },
+  {
+	"resourceType": "Observation",
+	"id": "example-observation",
+	"meta": {
+	  "profile": [
+		"http://onfhir.io/fhir/StructureDefinition/MyObservation"
+	  ]
+	},
+	"status": "final",
+	"basedOn": [
+	  {
+		"reference": "ServiceRequest/1"
+	  }
+	],
+	"category": [
+	  {
+		"coding": [
+		  {
+			"system": "http://terminology.hl7.org/CodeSystem/observation-category",
+			"code": "laboratory",
+			"display": "Laboratory"
+		  }
+		],
+		"text": "Laboratory"
+	  }
+	],
+	"code": {
+	  "coding": [
+		{
+		  "system": "http://loinc.org",
+		  "code": "2093-3",
+		  "display": "Body temperature"
+		}
+	  ],
+	  "text": "Body temperature"
+	},
+	"subject": {
+	  "reference": "Patient/example",
+	  "display": "Peter James Chalmers"
+	},
+	"encounter": {
+	  "reference": "Encounter/example-encounter",
+	  "display": "Ambulatory Encounter"
+	},
+	"effectiveDateTime": "2024-07-22T09:00:00Z",
+	"valueQuantity": {
+	  "value": 37.5,
+	  "unit": "Celsius",
+	  "system": "http://unitsofmeasure.org",
+	  "code": "Cel"
+	}
+  },
+  {
+	"resourceType": "Condition",
+	"id": "example-condition",
+	"clinicalStatus": {
+	  "coding": [
+		{
+		  "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+		  "code": "active",
+		  "display": "Active"
+		}
+	  ],
+	  "text": "Active"
+	},
+	"verificationStatus": {
+	  "coding": [
+		{
+		  "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+		  "code": "confirmed",
+		  "display": "Confirmed"
+		}
+	  ],
+	  "text": "Confirmed"
+	},
+	"code": {
+	  "coding": [
+		{
+		  "system": "http://snomed.info/sct",
+		  "code": "44054006",
+		  "display": "Hypertension"
+		}
+	  ],
+	  "text": "Hypertension"
+	},
+	"subject": {
+	  "reference": "Patient/example",
+	  "display": "Peter James Chalmers"
+	},
+	"encounter": {
+	  "reference": "Encounter/example-encounter",
+	  "display": "Ambulatory Encounter"
+	},
+	"onsetDateTime": "2024-07-22"
+  },
+  {
+	"resourceType": "Encounter",
+	"id": "example-encounter-2",
+	"status": "completed",
+	"class": [
+	  {
+		"coding": [
+		  {
+			"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+			"code": "EMER",
+			"display": "emergency"
+		  }
+		]
+	  }
+	],
+	"subject": {
+	  "reference": "Patient/example",
+	  "display": "Peter James Chalmers"
+	},
+	"plannedStartDate": "2024-08-01T10:00:00Z",
+	"plannedEndDate": "2024-08-02T09:00:00Z",
+	"serviceProvider": {
+	  "reference": "Organization/example-org",
+	  "display": "Example Organization"
+	}
+  },
+  {
+	"resourceType": "Observation",
+	"id": "example-observation-2",
+	"meta": {
+	  "profile": [
+		"http://onfhir.io/fhir/StructureDefinition/MyObservation"
+	  ]
+	},
+	"status": "preliminary",
+	"basedOn": [
+	  {
+		"reference": "ServiceRequest/2"
+	  }
+	],
+	"category": [
+	  {
+		"coding": [
+		  {
+			"system": "http://terminology.hl7.org/CodeSystem/observation-category",
+			"code": "vital-signs",
+			"display": "Vital Signs"
+		  }
+		],
+		"text": "Vital Signs"
+	  }
+	],
+	"code": {
+	  "coding": [
+		{
+		  "system": "http://loinc.org",
+		  "code": "85354-9",
+		  "display": "Blood pressure panel with all children optional"
+		}
+	  ],
+	  "text": "Blood Pressure"
+	},
+	"subject": {
+	  "reference": "Patient/example",
+	  "display": "Peter James Chalmers"
+	},
+	"encounter": {
+	  "reference": "Encounter/example-encounter-2",
+	  "display": "Emergency Encounter"
+	},
+	"effectiveDateTime": "2024-08-01T10:15:00Z",
+	"valueQuantity": {
+	  "value": 140,
+	  "unit": "mmHg",
+	  "system": "http://unitsofmeasure.org",
+	  "code": "mm[Hg]"
+	}
+  },
+  {
+	"resourceType": "Condition",
+	"id": "example-condition-2",
+	"clinicalStatus": {
+	  "coding": [
+		{
+		  "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+		  "code": "recurrence",
+		  "display": "Recurrence"
+		}
+	  ],
+	  "text": "Recurrence"
+	},
+	"verificationStatus": {
+	  "coding": [
+		{
+		  "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+		  "code": "confirmed",
+		  "display": "Confirmed"
+		}
+	  ],
+	  "text": "Confirmed"
+	},
+	"code": {
+	  "coding": [
+		{
+		  "system": "http://snomed.info/sct",
+		  "code": "38341003",
+		  "display": "Hypertensive disorder, systemic arterial"
+		}
+	  ],
+	  "text": "Hypertensive Disorder"
+	},
+	"subject": {
+	  "reference": "Patient/example",
+	  "display": "Peter James Chalmers"
+	},
+	"encounter": {
+	  "reference": "Encounter/example-encounter-2",
+	  "display": "Emergency Encounter"
+	},
+	"onsetDateTime": "2024-08-01"
+  }
+]

--- a/tofhir-engine/src/test/resources/test-mappings/from-fhir/encounter-summary-mapping.json
+++ b/tofhir-engine/src/test/resources/test-mappings/from-fhir/encounter-summary-mapping.json
@@ -1,0 +1,68 @@
+{
+  "id": "encounter-summary-mapping",
+  "url": "http://encounter-summary",
+  "name": "encounter-summary-mapping",
+  "title": "Encounter Summary Mapping",
+  "source": [
+	{
+	  "alias": "encounter",
+	  "url": "http://hl7.org/fhir/StructureDefinition/Encounter-R4",
+	  "joinOn": [
+		"id",
+		"subject.reference"
+	  ]
+	},
+	{
+	  "alias": "condition",
+	  "url": "http://hl7.org/fhir/StructureDefinition/Condition-R4",
+	  "joinOn": [
+		"encounter.reference"
+	  ]
+	},
+	{
+	  "alias": "observation",
+	  "url": "http://hl7.org/fhir/StructureDefinition/Observation-R4",
+	  "joinOn": [
+		"encounter.reference"
+	  ]
+	},
+	{
+	  "alias": "patient",
+	  "url": "http://hl7.org/fhir/StructureDefinition/Patient-R4",
+	  "joinOn": [
+		null,
+		"id"
+	  ]
+	}
+  ],
+  "context": {},
+  "variable": [],
+  "mapping": [
+	{
+	  "expression": {
+		"name": "encounter",
+		"language": "application/fhir-template+json",
+		"value": {
+		  "encounterId": "{{id}}",
+		  "patientId": "{{%patient.id}}",
+		  "gender": "{{%patient.gender}}",
+		  "birthDate": "{{%patient.birthDate}}",
+		  "encounterClass": "{{class.coding.where(system='http://terminology.hl7.org/CodeSystem/v3-ActCode').first().code}}",
+		  "encounterStart": "{{plannedStartDate}}",
+		  "encounterEnd": "{{plannedEndDate}}",
+		  "observationLoincCode": "{{%observation.first().code.coding.where(system='http://loinc.org').first().code}}",
+		  "observationDate": "{{%observation.first().effectiveDateTime}}",
+		  "observationResult": "{{%observation.first().valueQuantity.value}} {{%observation.first().valueQuantity.unit}}",
+		  "conditionSnomedCode": "{{%condition.first().code.coding.where(system='http://snomed.info/sct').code}}",
+		  "conditionDate": "{{%condition.first().onsetDateTime}}",
+		  "resourceType": null,
+		  "meta": {
+			"profile": [
+			  "http://encounter-summary"
+			]
+		  }
+		}
+	  }
+	}
+  ]
+}

--- a/tofhir-engine/src/test/resources/test-mappings/from-fhir/patient-mapping-from-fhir-two-sources.json
+++ b/tofhir-engine/src/test/resources/test-mappings/from-fhir/patient-mapping-from-fhir-two-sources.json
@@ -31,10 +31,10 @@
               "valueQuantity": "{{%observations.component.where(code.coding.system = 'http://loinc.org' and code.coding.code = '8310-5').select(valueQuantity.value).aggregate($total + $this, 0)}}"
           },{
             "url": "{{%sourceSystem.sourceUri}}/temp-avg",
-            "valueQuantity": "{{%observations.component.where(code.coding.system = 'http://loinc.org' and code.coding.code = '8310-5').agg:avg(valueQuantity.value)}}"
+            "valueQuantity": "{{? %observations.component.where(code.coding.system = 'http://loinc.org' and code.coding.code = '8310-5').agg:avg(valueQuantity.value)}}"
           },{
             "url": "{{%sourceSystem.sourceUri}}/resp-max",
-            "valueQuantity": "{{%observations.component.where(code.coding.system = 'http://loinc.org' and code.coding.code = '9279-1').agg:max(valueQuantity.value)}}"
+            "valueQuantity": "{{? %observations.component.where(code.coding.system = 'http://loinc.org' and code.coding.code = '9279-1').agg:max(valueQuantity.value)}}"
           }]
         }
       }

--- a/tofhir-server/src/main/scala/io/tofhir/server/endpoint/FhirDefinitionsEndpoint.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/endpoint/FhirDefinitionsEndpoint.scala
@@ -10,12 +10,14 @@ import io.tofhir.server.endpoint.FhirDefinitionsEndpoint.{DefinitionsQuery, QUER
 import io.tofhir.server.fhir.FhirDefinitionsConfig
 import io.tofhir.common.model.Json4sSupport._
 import io.tofhir.engine.util.MajorFhirVersion
+import io.tofhir.server.repository.mapping.IMappingRepository
+import io.tofhir.server.repository.schema.ISchemaRepository
 import io.tofhir.server.service.fhir.FhirDefinitionsService
 import io.tofhir.server.service.fhir.base.FhirBaseProfilesService
 
-class FhirDefinitionsEndpoint(fhirDefinitionsConfig: FhirDefinitionsConfig) extends LazyLogging {
+class FhirDefinitionsEndpoint(fhirDefinitionsConfig: FhirDefinitionsConfig,schemaRepository: ISchemaRepository, mappingRepository: IMappingRepository) extends LazyLogging {
 
-  val service: FhirDefinitionsService = new FhirDefinitionsService(fhirDefinitionsConfig)
+  val service: FhirDefinitionsService = new FhirDefinitionsService(fhirDefinitionsConfig,schemaRepository,mappingRepository)
 
   def route(request: ToFhirRestCall): Route =
     pathPrefix(SEGMENT_FHIR_DEFINITIONS) {

--- a/tofhir-server/src/main/scala/io/tofhir/server/endpoint/SchemaDefinitionEndpoint.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/endpoint/SchemaDefinitionEndpoint.scala
@@ -33,7 +33,7 @@ class SchemaDefinitionEndpoint(schemaRepository: ISchemaRepository, mappingRepos
       pathEndOrSingleSlash {
         parameterMap { queryParams =>
           queryParams.get("url") match {
-            case Some(url) => getSchemaByUrl(projectId, url)
+            case Some(url) => getSchemaByUrl(url)
             case None => getAllSchemas(request) ~ createSchema(projectId, queryParams.getOrElse("format", SchemaFormats.SIMPLE_STRUCTURE_DEFINITION)) // Operations on all schemas
           }
         }
@@ -114,10 +114,10 @@ class SchemaDefinitionEndpoint(schemaRepository: ISchemaRepository, mappingRepos
     }
   }
 
-  private def getSchemaByUrl(projectId: String, url: String): Route = {
+  private def getSchemaByUrl(url: String): Route = {
     get {
       complete {
-        service.getSchemaByUrl(projectId, url) map {
+        service.getSchemaByUrl(url) map {
           case Some(schemaDefinition) => StatusCodes.OK -> schemaDefinition
           case None => StatusCodes.NotFound -> {
             throw ResourceNotFound("Schema not found", s"Schema definition with url $url not found")

--- a/tofhir-server/src/main/scala/io/tofhir/server/endpoint/ToFhirServerEndpoint.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/endpoint/ToFhirServerEndpoint.scala
@@ -41,7 +41,7 @@ class ToFhirServerEndpoint(toFhirEngineConfig: ToFhirEngineConfig, webServerConf
   new FolderDBInitializer(schemaRepository, mappingRepository, mappingJobRepository, projectRepository, mappingContextRepository).init()
 
   val projectEndpoint = new ProjectEndpoint(schemaRepository, mappingRepository, mappingJobRepository, mappingContextRepository, projectRepository)
-  val fhirDefinitionsEndpoint = new FhirDefinitionsEndpoint(fhirDefinitionsConfig)
+  val fhirDefinitionsEndpoint = new FhirDefinitionsEndpoint(fhirDefinitionsConfig,schemaRepository, mappingRepository)
   val fhirPathFunctionsEndpoint = new FhirPathFunctionsEndpoint()
   val redcapEndpoint =  redCapServiceConfig.map(config => new RedCapEndpoint(config))
   val fileSystemTreeStructureEndpoint = new FileSystemTreeStructureEndpoint()

--- a/tofhir-server/src/main/scala/io/tofhir/server/repository/schema/AbstractSchemaRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/repository/schema/AbstractSchemaRepository.scala
@@ -1,15 +1,12 @@
 package io.tofhir.server.repository.schema
 
 import io.onfhir.api.parsers.IFhirFoundationResourceParser
-import io.onfhir.api.validation.ProfileRestrictions
 import io.onfhir.config.IFhirVersionConfigurator
 import io.onfhir.r4.config.FhirR4Configurator
 import io.onfhir.r4.parsers.R4Parser
 import io.onfhir.r5.config.FhirR5Configurator
-import io.tofhir.common.model.{DataTypeWithProfiles, SchemaDefinition, SimpleStructureDefinition}
 import io.tofhir.engine.config.ToFhirConfig
 import io.tofhir.engine.util.{FhirVersionUtil, MajorFhirVersion}
-import io.tofhir.server.service.fhir.SimpleStructureDefinitionService
 
 /**
  * Abstract class to provide common functionality to the implementations of ISchemaRepository
@@ -33,53 +30,4 @@ abstract class AbstractSchemaRepository extends ISchemaRepository {
     case MajorFhirVersion.R5 => new R4Parser()
     case _ => throw new NotImplementedError()
   }
-
-  /**
-   * Convert ProfileRestrictions into a SchemaDefinition instance.
-   *
-   * @param profileRestrictions
-   * @param id
-   * @param project
-   * @param simpleStructureDefinitionService
-   * @return
-   */
-  protected def convertToSchemaDefinition(profileRestrictions: ProfileRestrictions, simpleStructureDefinitionService: SimpleStructureDefinitionService): SchemaDefinition = {
-    val rootElementDefinition = createRootElement(profileRestrictions.resourceType)
-    SchemaDefinition(id = profileRestrictions.id.getOrElse(profileRestrictions.resourceType),
-      url = profileRestrictions.url,
-      `type` = profileRestrictions.resourceType,
-      name = profileRestrictions.resourceName.getOrElse(profileRestrictions.resourceType),
-      rootDefinition = Some(rootElementDefinition),
-      fieldDefinitions = Some(simpleStructureDefinitionService.simplifyStructureDefinition(profileRestrictions.url, withResourceTypeInPaths = true)))
-  }
-
-  /**
-   * Helper function to create the root element (1st element of the Element definitions which is dropped by IFhirFoundationParser.
-   *
-   * @param resourceType
-   * @return
-   */
-  private def createRootElement(resourceType: String): SimpleStructureDefinition = {
-    SimpleStructureDefinition(
-      id = resourceType,
-      path = resourceType,
-      dataTypes = Some(Seq(DataTypeWithProfiles("Element", None))),
-      isPrimitive = false,
-      isChoiceRoot = false,
-      isArray = false,
-      minCardinality = 0, maxCardinality = None,
-      boundToValueSet = None,
-      isValueSetBindingRequired = None,
-      referencableProfiles = None,
-      constraintDefinitions = None,
-      sliceDefinition = None,
-      sliceName = None,
-      fixedValue = None, patternValue = None,
-      referringTo = None,
-      short = None,
-      definition = None,
-      comment = None,
-      elements = None)
-  }
-
 }

--- a/tofhir-server/src/main/scala/io/tofhir/server/repository/schema/ISchemaRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/repository/schema/ISchemaRepository.scala
@@ -30,11 +30,11 @@ trait ISchemaRepository extends IFhirSchemaLoader {
 
   /**
    * Retrieve the schema identified by its url.
-   * @param projectId Project containing the schema definition
+   *
    * @param url URL of the schema definition
    * @return
    */
-  def getSchemaByUrl(projectId: String, url: String): Future[Option[SchemaDefinition]]
+  def getSchemaByUrl(url: String): Future[Option[SchemaDefinition]]
 
   /**
    * Save the schema to the repository.

--- a/tofhir-server/src/main/scala/io/tofhir/server/repository/schema/SchemaFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/repository/schema/SchemaFolderRepository.scala
@@ -284,7 +284,7 @@ class SchemaFolderRepository(schemaRepositoryFolderPath: String, projectFolderRe
         val source = Source.fromFile(f, StandardCharsets.UTF_8.name()) // read the JSON file
         val fileContent = try source.mkString finally source.close()
         val structureDefinition: ProfileRestrictions = fhirFoundationResourceParser.parseStructureDefinition(fileContent.parseJson)
-        val schema = convertToSchemaDefinition(structureDefinition, simpleStructureDefinitionService)
+        val schema = simpleStructureDefinitionService.convertToSchemaDefinition(structureDefinition)
         projectSchemas.put(schema.id, schema)
       }
 
@@ -398,7 +398,7 @@ class SchemaFolderRepository(schemaRepositoryFolderPath: String, projectFolderRe
 
       // To use convertToSchemaDefinition, profileRestrictions sequence must include the structure definition. Add it before conversion
       baseFhirConfig.profileRestrictions += structureDefinition.url -> structureDefinition
-      val schemaDefinition = convertToSchemaDefinition(structureDefinition, simpleStructureDefinitionService)
+      val schemaDefinition = simpleStructureDefinitionService.convertToSchemaDefinition(structureDefinition)
       // Remove structure definition from the cache and add it after file writing is done to ensure files and cache are the same
       baseFhirConfig.profileRestrictions -= structureDefinition.url
 

--- a/tofhir-server/src/main/scala/io/tofhir/server/repository/schema/SchemaFolderRepository.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/repository/schema/SchemaFolderRepository.scala
@@ -88,13 +88,12 @@ class SchemaFolderRepository(schemaRepositoryFolderPath: String, projectFolderRe
   /**
    * Retrieve the schema identified by its url.
    *
-   * @param projectId Project containing the schema definition
    * @param url       URL of the schema definition
    * @return
    */
-  override def getSchemaByUrl(projectId: String, url: String): Future[Option[SchemaDefinition]] = {
+  override def getSchemaByUrl(url: String): Future[Option[SchemaDefinition]] = {
     Future {
-      schemaDefinitions(projectId).values.find(_.url.equals(url))
+        schemaDefinitions.values.flatMap(_.values).find(_.url.equals(url))
     }
   }
 

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/SchemaDefinitionService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/SchemaDefinitionService.scala
@@ -46,12 +46,11 @@ class SchemaDefinitionService(schemaRepository: ISchemaRepository, mappingReposi
 
   /**
    * Get a schema definition by its URL from the schema repository
-   * @param projectId Project containing the schema definition
    * @param url URL of the schema definition
    * @return
    */
-  def getSchemaByUrl(projectId: String, url: String): Future[Option[SchemaDefinition]] = {
-    schemaRepository.getSchemaByUrl(projectId, url)
+  def getSchemaByUrl(url: String): Future[Option[SchemaDefinition]] = {
+    schemaRepository.getSchemaByUrl(url)
   }
 
   /**

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/fhir/SimpleStructureDefinitionService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/fhir/SimpleStructureDefinitionService.scala
@@ -11,6 +11,22 @@ import org.json4s.jackson.Serialization
 class SimpleStructureDefinitionService(fhirConfig: BaseFhirConfig) {
 
   /**
+   * Convert ProfileRestrictions into a SchemaDefinition instance.
+   *
+   * @param profileRestrictions
+   * @return
+   */
+  def convertToSchemaDefinition(profileRestrictions: ProfileRestrictions): SchemaDefinition = {
+    val rootElementDefinition = createRootElement(profileRestrictions.resourceType)
+    SchemaDefinition(id = profileRestrictions.id.getOrElse(profileRestrictions.resourceType),
+      url = profileRestrictions.url,
+      `type` = profileRestrictions.resourceType,
+      name = profileRestrictions.resourceName.getOrElse(profileRestrictions.resourceType),
+      rootDefinition = Some(rootElementDefinition),
+      fieldDefinitions = Some(simplifyStructureDefinition(profileRestrictions.url, withResourceTypeInPaths = true)))
+  }
+
+  /**
    * Given a URL for a profile, return a sequence of definitions for all elements of the resource type indicated by this profile.
    *
    * @param profileUrl              The URL of the profile to be simplified.
@@ -398,4 +414,32 @@ class SimpleStructureDefinitionService(fhirConfig: BaseFhirConfig) {
       elements = None)
   }
 
+  /**
+   * Helper function to create the root element (1st element of the Element definitions which is dropped by IFhirFoundationParser.
+   *
+   * @param resourceType
+   * @return
+   */
+  private def createRootElement(resourceType: String): SimpleStructureDefinition = {
+    SimpleStructureDefinition(
+      id = resourceType,
+      path = resourceType,
+      dataTypes = Some(Seq(DataTypeWithProfiles("Element", None))),
+      isPrimitive = false,
+      isChoiceRoot = false,
+      isArray = false,
+      minCardinality = 0, maxCardinality = None,
+      boundToValueSet = None,
+      isValueSetBindingRequired = None,
+      referencableProfiles = None,
+      constraintDefinitions = None,
+      sliceDefinition = None,
+      sliceName = None,
+      fixedValue = None, patternValue = None,
+      referringTo = None,
+      short = None,
+      definition = None,
+      comment = None,
+      elements = None)
+  }
 }

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/fhir/base/FhirBaseProfilesService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/fhir/base/FhirBaseProfilesService.scala
@@ -1,0 +1,88 @@
+package io.tofhir.server.service.fhir.base
+
+import io.onfhir.api.FHIR_FOUNDATION_RESOURCES.FHIR_STRUCTURE_DEFINITION
+import io.onfhir.api.Resource
+import io.onfhir.api.util.FHIRUtil
+import io.onfhir.api.validation.ProfileRestrictions
+import io.onfhir.config.{BaseFhirServerConfigurator, FSConfigReader}
+import io.onfhir.r4.parsers.R4Parser
+import io.tofhir.common.model.SchemaDefinition
+import io.tofhir.engine.util.MajorFhirVersion
+import io.tofhir.server.service.fhir.SimpleStructureDefinitionService
+
+/**
+ * Abstract class representing a service for managing FHIR base profiles.
+ * Provides methods to retrieve resource types and profile schemas.
+ */
+abstract class FhirBaseProfilesService {
+  /** A configuration reader for reading FHIR-related configuration. */
+  val configReader: FSConfigReader
+  /** A configurator for setting up the FHIR server platform. */
+  val fhirServerConfigurator: BaseFhirServerConfigurator
+  /** A sequence of base profile resources read from a configuration file. */
+  private lazy val baseProfileResources = configReader.readStandardBundleFile("profiles-resources.json", Set(FHIR_STRUCTURE_DEFINITION))
+  /** A sequence of resource types derived from base profile resources. */
+  lazy val resourceTypes: Seq[String] = baseProfileResources.flatMap(getTypeFromStructureDefinition)
+  /** A service to create SchemaDefinitions from the base profiles. */
+  lazy val simpleStructureDefinitionService: SimpleStructureDefinitionService = new SimpleStructureDefinitionService(fhirServerConfigurator.initializePlatform(configReader))
+
+  /**
+   * Retrieves a sequence of schema definitions based on the given profile URLs.
+   *
+   * @param url A comma-separated string of profile URLs.
+   * @return A sequence of schema definitions corresponding to the provided profile URLs.
+   */
+  def getProfile(url: String): Seq[SchemaDefinition] = {
+    // split the provided URL string into a set of individual profile URLs
+    val profileUrls = url.split(",").toSet
+
+    baseProfileResources
+      // filter the base profile resources to include only those with URLs matching the provided profile URLs
+      .filter(p => profileUrls.contains(FHIRUtil.extractValueOption[String](p, "url").get))
+      // map each filtered resource to a schema definition
+      .map(resource => {
+      // parse the structure definition from the resource
+      val structureDefinition: ProfileRestrictions = new R4Parser().parseStructureDefinition(resource)
+      // convert the parsed structure definition to a schema definition
+      simpleStructureDefinitionService.convertToSchemaDefinition(structureDefinition)
+    })
+  }
+
+  /**
+   * Extracts the type from a given structure definition resource.
+   *
+   * @param structureDefinition The structure definition resource.
+   * @return An optional string representing the resource type, or None if the resource is abstract.
+   */
+  private def getTypeFromStructureDefinition(structureDefinition: Resource): Option[String] = {
+    if (FHIRUtil.extractValueOption[Boolean](structureDefinition, "abstract").get)
+      None
+    else
+      Some(FHIRUtil.extractValueOption[String](structureDefinition, "type").get)
+  }
+}
+
+/**
+ * Companion object for FhirBaseProfilesService providing factory methods to create instances
+ * based on the FHIR version.
+ */
+object FhirBaseProfilesService {
+  /** Lazily initialized instance for FHIR R4 base profiles service. */
+  lazy private val r4FhirBaseProfilesService = new R4FhirBaseProfilesService
+  /** Lazily initialized instance for FHIR R5 base profiles service. */
+  lazy private val r5FhirBaseProfilesService = new R5FhirBaseProfilesService
+
+  /**
+   * Factory method to create a FhirBaseProfilesService instance based on the FHIR version.
+   *
+   * @param fhirVersion The FHIR version (e.g., "R4", "R5").
+   * @return An instance of FhirBaseProfilesService for the specified FHIR version.
+   */
+  def apply(fhirVersion: String): FhirBaseProfilesService = {
+    fhirVersion match {
+      case MajorFhirVersion.R4 => r4FhirBaseProfilesService
+      case MajorFhirVersion.R5 => r5FhirBaseProfilesService
+      case _ => throw new NotImplementedError()
+    }
+  }
+}

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/fhir/base/R4FhirBaseProfilesService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/fhir/base/R4FhirBaseProfilesService.scala
@@ -1,0 +1,13 @@
+package io.tofhir.server.service.fhir.base
+
+import io.onfhir.config.{BaseFhirServerConfigurator, FSConfigReader}
+import io.onfhir.r4.config.FhirR4Configurator
+import io.tofhir.engine.util.MajorFhirVersion
+
+/**
+ * Implementation of FhirBaseProfilesService for FHIR R4.
+ */
+class R4FhirBaseProfilesService extends FhirBaseProfilesService {
+  override val configReader: FSConfigReader = new FSConfigReader(fhirVersion = MajorFhirVersion.R4)
+  override val fhirServerConfigurator: BaseFhirServerConfigurator = new FhirR4Configurator()
+}

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/fhir/base/R5FhirBaseProfilesService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/fhir/base/R5FhirBaseProfilesService.scala
@@ -1,0 +1,13 @@
+package io.tofhir.server.service.fhir.base
+
+import io.onfhir.config.{BaseFhirServerConfigurator, FSConfigReader}
+import io.onfhir.r5.config.FhirR5Configurator
+import io.tofhir.engine.util.MajorFhirVersion
+
+/**
+ * Implementation of FhirBaseProfilesService for FHIR R5.
+ */
+class R5FhirBaseProfilesService extends FhirBaseProfilesService {
+  override val configReader: FSConfigReader = new FSConfigReader(fhirVersion = MajorFhirVersion.R5)
+  override val fhirServerConfigurator: BaseFhirServerConfigurator = new FhirR5Configurator()
+}

--- a/tofhir-server/src/test/resources/fhir-resources/patient-resource.json
+++ b/tofhir-server/src/test/resources/fhir-resources/patient-resource.json
@@ -1,0 +1,39 @@
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "active": true,
+  "name": [
+	{
+	  "use": "official",
+	  "family": "Chalmers",
+	  "given": [
+		"Peter",
+		"James"
+	  ]
+	}
+  ],
+  "telecom": [
+	{
+	  "system": "phone",
+	  "value": "(03) 5555 6473",
+	  "use": "work"
+	}
+  ],
+  "gender": "male",
+  "birthDate": "1974-12-25",
+  "deceasedBoolean": false,
+  "address": [
+	{
+	  "use": "home",
+	  "type": "both",
+	  "line": [
+		"534 Erewhon St"
+	  ],
+	  "city": "PleasantVille",
+	  "district": "Rainbow",
+	  "state": "Vic",
+	  "postalCode": "3999",
+	  "country": "Australia"
+	}
+  ]
+}

--- a/tofhir-server/src/test/resources/test-mappings/patient-flat-mapping.json
+++ b/tofhir-server/src/test/resources/test-mappings/patient-flat-mapping.json
@@ -1,0 +1,38 @@
+{
+  "id": "patient-flat-mapping",
+  "url": "http://patient-flat-mapping",
+  "name": "patient-flat-mapping",
+  "title": "Patient Flat Mapping",
+  "source": [
+	{
+	  "alias": "patient",
+	  "url": "http://hl7.org/fhir/StructureDefinition/Patient-R4",
+	  "joinOn": []
+	}
+  ],
+  "context": {},
+  "variable": [],
+  "mapping": [
+	{
+	  "expression": {
+		"name": "flatPatient",
+		"language": "application/fhir-template+json",
+		"value": {
+		  "id": "{{id}}",
+		  "active": "{{active}}",
+		  "officialName": "{{name.where(use='official').first().given[0]}} {{name.where(use='official').first().family}}",
+		  "phone": "{{telecom.where(system='phone').first().value}}",
+		  "gender": "{{gender}}",
+		  "birthDate": "{{birthDate}}",
+		  "homeCountry": "{{address.where(use='home').first().country}}",
+		  "resourceType": null,
+		  "meta": {
+			"profile": [
+			  "http://patient-flat-schema"
+			]
+		  }
+		}
+	  }
+	}
+  ]
+}

--- a/tofhir-server/src/test/scala/io/tofhir/server/endpoint/FhirDefinitionsEndpointTest.scala
+++ b/tofhir-server/src/test/scala/io/tofhir/server/endpoint/FhirDefinitionsEndpointTest.scala
@@ -3,13 +3,14 @@ package io.tofhir.server.endpoint
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import io.tofhir.OnFhirTestContainer
 import io.tofhir.common.model.Json4sSupport.formats
-import io.tofhir.common.model.SchemaDefinition
+import io.tofhir.common.model.{DataTypeWithProfiles, SchemaDefinition, SimpleStructureDefinition}
 import io.tofhir.engine.util.MajorFhirVersion
 import io.tofhir.server.BaseEndpointTest
-import io.tofhir.server.endpoint.FhirDefinitionsEndpoint
+import io.tofhir.server.endpoint.FhirDefinitionsEndpoint.{DefinitionsQuery, QUERY_PARAM_PROFILE, QUERY_PARAM_Q}
 import org.json4s.JsonAST.{JString, JValue}
 import org.json4s._
 import org.json4s.jackson.JsonMethods
+import org.json4s.jackson.Serialization.writePretty
 
 import scala.io.Source
 
@@ -24,6 +25,14 @@ class FhirDefinitionsEndpointTest extends BaseEndpointTest with OnFhirTestContai
   val conditionResourceJson: String = Source.fromInputStream(getClass.getResourceAsStream("/fhir-resources/condition-resource.json")).mkString
   // Condition resource with missing subject
   val invalidConditionResourceJson: String = Source.fromInputStream(getClass.getResourceAsStream("/fhir-resources/invalid-condition-resource.json")).mkString
+
+  /**
+   * Creates a project to be used in the tests.
+   * */
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    this.createProject()
+  }
 
   "Fhir definitions endpoint" should {
 
@@ -146,6 +155,49 @@ class FhirDefinitionsEndpointTest extends BaseEndpointTest with OnFhirTestContai
         responseBody.last.url shouldEqual "http://hl7.org/fhir/StructureDefinition/Patient"
         responseBody.last.id shouldEqual "Patient"
         responseBody.last.fieldDefinitions.get.length shouldEqual 22
+      }
+    }
+
+    /**
+     * Test case to verify retrieval of simplified element definitions for a given FHIR profile.
+     * */
+    "retrieve simplified element definitions of a FHIR profile" in {
+      Get(s"/${webServerConfig.baseUri}/${FhirDefinitionsEndpoint.SEGMENT_FHIR_DEFINITIONS}?$QUERY_PARAM_Q=${DefinitionsQuery.ELEMENTS}&$QUERY_PARAM_PROFILE=http://hl7.org/fhir/StructureDefinition/Patient") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        JsonMethods.parse(responseAs[String]).extract[Seq[SimpleStructureDefinition]].length shouldEqual 22
+      }
+    }
+
+    /**
+     * Test case to verify retrieval of simplified element definitions for a given schema.
+     *
+     * This test performs the following steps:
+     * 1. Creates a schema with two elements and posts it to the Schema Definition endpoint.
+     * 2. Sends a GET request to the FHIR Definitions endpoint with the schema URL and expects
+     * a sequence of SimpleStructureDefinition objects to be returned in the response.
+     */
+    "retrieve simplified element definitions of a schema" in {
+      // create a schema with two elements
+      val schemaUrl: String = "https://example.com/fhir/StructureDefinition/schema"
+      val schema: SchemaDefinition = SchemaDefinition(url = schemaUrl, `type` = "Ty", name = "name", rootDefinition = None, fieldDefinitions = Some(Seq(
+        SimpleStructureDefinition(id = "element-with-definition",
+          path = "Ty.element-with-definition", dataTypes = Some(Seq(DataTypeWithProfiles(dataType = "canonical", profiles = Some(Seq("http://hl7.org/fhir/StructureDefinition/canonical"))))), isPrimitive = true,
+          isChoiceRoot = false, isArray = false, minCardinality = 0, maxCardinality = None,
+          boundToValueSet = None, isValueSetBindingRequired = None, referencableProfiles = None, constraintDefinitions = None, sliceDefinition = None,
+          sliceName = None, fixedValue = None, patternValue = None, referringTo = None, short = Some("element-with-definition"), definition = Some("element definition"), comment = None, elements = None),
+        SimpleStructureDefinition(id = "element-with-no-definition",
+          path = "Ty.element-with-no-definition", dataTypes = Some(Seq(DataTypeWithProfiles(dataType = "canonical", profiles = Some(Seq("http://hl7.org/fhir/StructureDefinition/canonical"))))), isPrimitive = true,
+          isChoiceRoot = false, isArray = false, minCardinality = 0, maxCardinality = None,
+          boundToValueSet = None, isValueSetBindingRequired = None, referencableProfiles = None, constraintDefinitions = None, sliceDefinition = None,
+          sliceName = None, fixedValue = None, patternValue = None, referringTo = None, short = Some("element-with-no-definition"), definition = None, comment = None, elements = None)
+      )))
+      Post(s"/${webServerConfig.baseUri}/${ProjectEndpoint.SEGMENT_PROJECTS}/$projectId/${SchemaDefinitionEndpoint.SEGMENT_SCHEMAS}", HttpEntity(ContentTypes.`application/json`, writePretty(schema))) ~> route ~> check {
+        status shouldEqual StatusCodes.Created
+      }
+      // retrieve the simplified element definitions of this schema
+      Get(s"/${webServerConfig.baseUri}/${FhirDefinitionsEndpoint.SEGMENT_FHIR_DEFINITIONS}?$QUERY_PARAM_Q=${DefinitionsQuery.ELEMENTS}&$QUERY_PARAM_PROFILE=$schemaUrl") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        JsonMethods.parse(responseAs[String]).extract[Seq[SimpleStructureDefinition]].length shouldEqual 2
       }
     }
   }

--- a/tofhir-server/src/test/scala/io/tofhir/server/endpoint/FhirDefinitionsEndpointTest.scala
+++ b/tofhir-server/src/test/scala/io/tofhir/server/endpoint/FhirDefinitionsEndpointTest.scala
@@ -2,6 +2,9 @@ package io.tofhir.server.endpoint
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import io.tofhir.OnFhirTestContainer
+import io.tofhir.common.model.Json4sSupport.formats
+import io.tofhir.common.model.SchemaDefinition
+import io.tofhir.engine.util.MajorFhirVersion
 import io.tofhir.server.BaseEndpointTest
 import io.tofhir.server.endpoint.FhirDefinitionsEndpoint
 import org.json4s.JsonAST.{JString, JValue}
@@ -87,6 +90,62 @@ class FhirDefinitionsEndpointTest extends BaseEndpointTest with OnFhirTestContai
         (thirdEntryFirstIssue \ "code") should be(JString("invalid"))
         (thirdEntryFirstIssue \ "diagnostics").asInstanceOf[JString].s.split(" => ").last should be("Invalid value 'test' for FHIR primitive type 'date'!")
         (thirdEntryFirstIssue \ "expression").asInstanceOf[JArray].arr.head should be(JString("birthDate"))
+      }
+    }
+
+    /**
+     * Test suite for retrieving base FHIR resources via the FHIR Definitions endpoint.
+     */
+    "retrieve base FHIR resources" in {
+      /**
+       * Test case to check if a BadRequest status is returned when the query parameter 'fhirVersion' is missing.
+       */
+      Get(s"/${webServerConfig.baseUri}/${FhirDefinitionsEndpoint.SEGMENT_BASE_PROFILES}") ~> route ~> check {
+        status shouldEqual StatusCodes.BadRequest
+        responseAs[String] should include("Detail: base-profiles path cannot be invoked without the query parameter 'fhirVersion'.")
+      }
+
+      /**
+       * Test case to check if the correct base FHIR resource types are returned for FHIR version R4.
+       */
+      Get(s"/${webServerConfig.baseUri}/${FhirDefinitionsEndpoint.SEGMENT_BASE_PROFILES}?${FhirDefinitionsEndpoint.QUERY_PARAM_FHIR_VERSION}=${MajorFhirVersion.R4}") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        JsonMethods.parse(responseAs[String]).extract[List[String]].length shouldEqual 147
+      }
+
+      /**
+       * Test case to check if a BadRequest status is returned when an invalid FHIR version is provided.
+       */
+      Get(s"/${webServerConfig.baseUri}/${FhirDefinitionsEndpoint.SEGMENT_BASE_PROFILES}?${FhirDefinitionsEndpoint.QUERY_PARAM_FHIR_VERSION}=R6") ~> route ~> check {
+        status shouldEqual StatusCodes.BadRequest
+        responseAs[String] should include("Detail: fhirVersion on base-profiles cannot take the value: R6. Possible values are: R4 and R5")
+      }
+
+      /**
+       * Test case to check if the correct schema definition is returned for a single profile URL with FHIR version R4.
+       */
+      Get(s"/${webServerConfig.baseUri}/${FhirDefinitionsEndpoint.SEGMENT_BASE_PROFILES}?${FhirDefinitionsEndpoint.QUERY_PARAM_FHIR_VERSION}=${MajorFhirVersion.R4}&${FhirDefinitionsEndpoint.QUERY_PARAM_PROFILE}=http://hl7.org/fhir/StructureDefinition/Patient") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        val responseBody = JsonMethods.parse(responseAs[String]).extract[Seq[SchemaDefinition]]
+        responseBody.length shouldEqual 1
+        responseBody.head.url shouldEqual "http://hl7.org/fhir/StructureDefinition/Patient"
+        responseBody.head.id shouldEqual "Patient"
+        responseBody.head.fieldDefinitions.get.length shouldEqual 22
+      }
+
+      /**
+       * Test case to check if the correct schema definitions are returned for multiple profile URLs with FHIR version R4.
+       */
+      Get(s"/${webServerConfig.baseUri}/${FhirDefinitionsEndpoint.SEGMENT_BASE_PROFILES}?${FhirDefinitionsEndpoint.QUERY_PARAM_FHIR_VERSION}=${MajorFhirVersion.R4}&${FhirDefinitionsEndpoint.QUERY_PARAM_PROFILE}=http://hl7.org/fhir/StructureDefinition/Patient,http://hl7.org/fhir/StructureDefinition/Condition") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        val responseBody = JsonMethods.parse(responseAs[String]).extract[Seq[SchemaDefinition]]
+        responseBody.length shouldEqual 2
+        responseBody.head.url shouldEqual "http://hl7.org/fhir/StructureDefinition/Condition"
+        responseBody.head.id shouldEqual "Condition"
+        responseBody.head.fieldDefinitions.get.length shouldEqual 23
+        responseBody.last.url shouldEqual "http://hl7.org/fhir/StructureDefinition/Patient"
+        responseBody.last.id shouldEqual "Patient"
+        responseBody.last.fieldDefinitions.get.length shouldEqual 22
       }
     }
   }


### PR DESCRIPTION
- Implemented an endpoint to retrieve base FHIR profiles
- Modified `FileSystemWriter` to write generated resources to a CSV file
- Modified `FhirDefinitionsService` to return simplified element definitions of a schema
- Refactored `handleJoin` method and improved its documentation
- Added a test case for joining multiple FHIR resources and writing to a CSV file