### PR TITLE
Infer schema options

### DIFF
--- a/tofhir-server/api.yaml
+++ b/tofhir-server/api.yaml
@@ -2015,6 +2015,20 @@ components:
           oneOf:
             - $ref: "#/components/schemas/FileSystemSource"
             - $ref: "#/components/schemas/SqlSource"
+        inferenceType:
+          type: string
+          description: "Defines how the inference operation will be done"
+          enum:
+            - append
+            - overwrite
+        fieldDefinitions:
+          type: array
+          description: |
+            Defines the application of inferred fields when updating schemas:
+            - `"append"`: Retain existing schema fields and add inferred fields.
+            - `"overwrite"`: Replace all existing schema fields with inferred fields.
+          items:
+            $ref: '#/components/schemas/SimpleStructureDefinition'
       required:
         - name
         - sourceSettings

--- a/tofhir-server/src/main/scala/io/tofhir/server/model/InferTask.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/model/InferTask.scala
@@ -1,5 +1,6 @@
 package io.tofhir.server.model
 
+import io.tofhir.common.model.SimpleStructureDefinition
 import io.tofhir.engine.model.{MappingJobSourceSettings, MappingSourceBinding}
 
 /**
@@ -8,5 +9,17 @@ import io.tofhir.engine.model.{MappingJobSourceSettings, MappingSourceBinding}
  * @param name alias for source binding
  * @param mappingJobSourceSettings connection details for data source (e.g. JDBC connection details, file path)
  * @param sourceBinding mapping task source configuration (e.g. file name, table name, query)
+ * @param inferenceType specifies how inferred fields should be applied when updating schemas:
+ *                  - `"append"`: Infer the schema by preserving existing fields
+ *                  - `"overwrite"`: Remove existing schema fields and return inferred fields.
+ * @param fieldDefinitions an optional sequence of field definitions that represent the existing schema fields
  */
-case class InferTask(name: String, mappingJobSourceSettings: Map[String, MappingJobSourceSettings], sourceBinding: MappingSourceBinding)
+case class InferTask(name: String, mappingJobSourceSettings: Map[String, MappingJobSourceSettings], sourceBinding: MappingSourceBinding, inferenceType: String, fieldDefinitions: Option[Seq[SimpleStructureDefinition]])
+
+/**
+ * Enumeration of possible inference types.
+ */
+object InferenceTypes {
+  val Append = "append"
+  val OverWrite = "overwrite"
+}


### PR DESCRIPTION
Added functionality to allow users to choose between "Overwrite" or "Append" when updating schemas with inferred properties.
Details:
- Overwrite: If selected, all existing fields in the schema will be removed, and only the fields from the inferred schema will remain.

- Append: If selected, the existing fields in the schema will be preserved. New fields from the inferred schema will be added. If a field in the inferred schema shares the same ID as an existing field, the existing field will be replaced by the inferred one.