### PR TITLE
:bug: getATC (rxnorm library) returns a list of ATC codes instead of …

### DIFF
--- a/tofhir-rxnorm/src/main/scala/io/tofhir/rxnorm/RxNormApiClient.scala
+++ b/tofhir-rxnorm/src/main/scala/io/tofhir/rxnorm/RxNormApiClient.scala
@@ -135,12 +135,12 @@ case class RxNormApiClient(rxNormApiRootUrl:String, timeoutInSec:Int) {
   }
 
   /**
-   * Get corresponding ATC code for a RxNorm ingredient concept
+   * Get corresponding ATC codes for a RxNorm ingredient concept
    * See https://lhncbc.nlm.nih.gov/RxNav/APIs/api-RxNorm.getRxProperty.html
    * @param rxcui Concept id
    * @return
    */
-  def getAtcCode(rxcui:String):Option[String] = {
+  def getAtcCode(rxcui:String):Seq[String] = {
     val uri:String = s"$rxNormApiRootUrl/REST/rxcui/$rxcui/property.json?propName=ATC"
     val request =
       HttpRequest
@@ -152,8 +152,8 @@ case class RxNormApiClient(rxNormApiRootUrl:String, timeoutInSec:Int) {
       .flatMap(response =>
         FHIRUtil
           .extractValueOptionByPath[Seq[String]](response, "propConceptGroup.propConcept.propValue")
-          .flatMap(_.headOption)
-      )
+          .map(_.filter(r => r != "" && r != "/")))
+      .getOrElse(Nil)
   }
 
   /**

--- a/tofhir-rxnorm/src/main/scala/io/tofhir/rxnorm/RxNormApiFunctionLibrary.scala
+++ b/tofhir-rxnorm/src/main/scala/io/tofhir/rxnorm/RxNormApiFunctionLibrary.scala
@@ -166,16 +166,13 @@ class RxNormApiFunctionLibrary(rxNormApiClient:RxNormApiClient, context: FhirPat
     inputType = Seq("string")
   )
   def getATC(rxcuiExpr:ExpressionContext): Seq[FhirPathResult] = {
-    val rxcui: Option[String] =
+    val rxcui: String =
       evaluator.visit(rxcuiExpr) match {
-        case Seq(FhirPathString(s)) => Some(s)
-        case Nil => None
+        case Seq(FhirPathString(s)) => s
         case _ => throw new FhirPathException("Invalid parameter rxcui! It should evaluate to a single string")
       }
-    rxcui
-      .flatMap(rxNormApiClient.getAtcCode)
+    rxNormApiClient.getAtcCode(rxcui)
       .map(FhirPathString)
-      .toSeq
   }
 }
 

--- a/tofhir-rxnorm/src/test/scala/RxNormApiClientTest.scala
+++ b/tofhir-rxnorm/src/test/scala/RxNormApiClientTest.scala
@@ -35,7 +35,7 @@ class RxNormApiClientTest extends AnyFlatSpec with Matchers {
   }
 
   it should "get the ATC code for given RxNorm concept id" in {
-    client.getAtcCode("276237") shouldBe Some("J05AF09")
+    client.getAtcCode("276237") shouldBe Seq("J05AF09")
   }
 
 }


### PR DESCRIPTION
…a single because one rxcui could have multiple ATC codes