### PR TITLE
Read the configuration of external function libraries from application.conf file

### DIFF
--- a/tofhir-engine/src/main/resources/application.conf
+++ b/tofhir-engine/src/main/resources/application.conf
@@ -71,6 +71,17 @@ tofhir {
 
   # Database folder of toFHIR (e.g., to maintain synchronization times for scheduled jobs)
   db-path = "tofhir-db"
+
+  # External function libraries containing function to be used within FHIRPath expressions
+  # functionLibraries {
+  #  rxn {
+  #    className = "io.tofhir.rxnorm.RxNormApiFunctionLibraryFactory"
+  #    args = ["https://rxnav.nlm.nih.gov", 2]
+  #  }
+  #  cst {
+  #    className = "io.tofhir.common.util.CustomMappingFunctionsFactory"
+  #  }
+  # }
 }
 
 # Spark configurations

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/Boot.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/Boot.scala
@@ -1,7 +1,6 @@
 package io.tofhir.engine
 
 import com.typesafe.scalalogging.Logger
-import io.onfhir.path.IFhirPathFunctionLibraryFactory
 import io.tofhir.common.app.AppVersion
 import io.tofhir.engine.cli.command.{CommandExecutionContext, CommandFactory}
 import io.tofhir.engine.cli.CommandLineInterface
@@ -17,16 +16,16 @@ object Boot extends App {
 
   init(args)
 
-  def init(args: Array[String], functionLibraryFactories: Map[String, IFhirPathFunctionLibraryFactory] = Map.empty): Unit = {
+  def init(args: Array[String]): Unit = {
     val options = CommandLineInterface.nextArg(Map(), args.toList)
     //Interactive command line interface
     if (options.isEmpty || !options.contains("command") || options("command").asInstanceOf[String] == "cli") {
-      val toFhirEngine = new ToFhirEngine(functionLibraryFactories = functionLibraryFactories)
+      val toFhirEngine = new ToFhirEngine()
       CommandLineInterface.start(toFhirEngine, ToFhirConfig.engineConfig.initialMappingJobFilePath)
     }
     // Extract schemas from a REDCap data dictionary
     else if (options("command").asInstanceOf[String] == "extract-redcap-schemas") {
-      val toFhirEngine = new ToFhirEngine(functionLibraryFactories = functionLibraryFactories)
+      val toFhirEngine = new ToFhirEngine()
       // get parameters
       val dataDictionary = options.get("data-dictionary").map(_.asInstanceOf[String])
       val definitionRootUrl = options.get("definition-root-url").map(_.asInstanceOf[String])
@@ -37,7 +36,7 @@ object Boot extends App {
     }
     //Run as batch job
     else if (options("command").asInstanceOf[String] == "run") {
-      val toFhirEngine = new ToFhirEngine(functionLibraryFactories = functionLibraryFactories)
+      val toFhirEngine = new ToFhirEngine()
       val mappingJobFilePath =
         if (options.contains("job"))
           options.get("job").map(_.asInstanceOf[String])

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/ToFhirEngine.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/ToFhirEngine.scala
@@ -19,9 +19,8 @@ import org.apache.spark.sql.SparkSession
  *
  * @param mappingRepository        Already instantiated mapping repository that maintains a dynamically-updated data structure based on the operations on the mappings
  * @param schemaRepository         Already instantiated schema repository that maintains a dynamically-updated data structure based on the operations on the schemas
- * @param functionLibraryFactories External function libraries containing function to be used within FHIRPath expressions
  */
-class ToFhirEngine(mappingRepository: Option[IFhirMappingRepository] = None, schemaRepository: Option[IFhirSchemaLoader] = None, functionLibraryFactories: Map[String, IFhirPathFunctionLibraryFactory] = Map.empty) {
+class ToFhirEngine(mappingRepository: Option[IFhirMappingRepository] = None, schemaRepository: Option[IFhirSchemaLoader] = None) {
   // Validate that both mapping and schema repositories are empty or non-empty
   if (mappingRepository.nonEmpty && schemaRepository.isEmpty || mappingRepository.isEmpty && schemaRepository.nonEmpty) {
     throw EngineInitializationException("Mapping and schema repositories should both empty or non-empty")
@@ -56,12 +55,15 @@ class ToFhirEngine(mappingRepository: Option[IFhirMappingRepository] = None, sch
    * @return
    */
   private def initializeFunctionLibraries(): Map[String, IFhirPathFunctionLibraryFactory] = {
+    val externalFunctionLibraryFactories: Map[String, IFhirPathFunctionLibraryFactory] = engineConfig.functionLibrariesConfig
+      .map(_.functionLibrariesFactories)
+      .getOrElse(Map.empty)
     Map(
       FhirPathUtilFunctionsFactory.defaultPrefix -> FhirPathUtilFunctionsFactory,
       FhirPathNavFunctionsFactory.defaultPrefix -> FhirPathNavFunctionsFactory,
       FhirPathAggFunctionsFactory.defaultPrefix -> FhirPathAggFunctionsFactory,
       FhirPathIdentityServiceFunctionsFactory.defaultPrefix -> FhirPathIdentityServiceFunctionsFactory,
       FhirPathTerminologyServiceFunctionsFactory.defaultPrefix -> FhirPathTerminologyServiceFunctionsFactory
-    ) ++ functionLibraryFactories
+    ) ++ externalFunctionLibraryFactories
   }
 }

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/config/FunctionLibrariesConfig.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/config/FunctionLibrariesConfig.scala
@@ -1,0 +1,67 @@
+package io.tofhir.engine.config
+
+import com.typesafe.config.Config
+import io.onfhir.path.IFhirPathFunctionLibraryFactory
+
+/**
+ * A configuration class responsible for loading external function libraries for FHIRPath expressions. It dynamically
+ * initializes instances of function libraries and retrieves their package names.
+ *
+ * @param librariesConfig The configuration object containing the definitions of function libraries.
+ */
+class FunctionLibrariesConfig(librariesConfig: Config) {
+
+  /**
+   * A tuple containing a lazy-loaded map of function library factories and a list of package names.
+   *
+   * - `functionLibrariesFactories`: A map where the keys are library names (as defined in the configuration)
+   * and the values are instances of `IFhirPathFunctionLibraryFactory`.
+   * - `libraryPackageNames`: A sequence of package names for the dynamically loaded function library classes.
+   */
+  lazy val (functionLibrariesFactories: Map[String, IFhirPathFunctionLibraryFactory], libraryPackageNames: Seq[String]) = loadFunctionLibraryFactories()
+
+  /**
+   * Loads function library factories and their corresponding package names based on the provided configuration.
+   *
+   * @return A tuple containing:
+   *         - A map of function library names to their respective instances (`Map[String, IFhirPathFunctionLibraryFactory]`).
+   *         - A sequence of package names for the loaded classes (`Seq[String]`).
+   * @throws IllegalArgumentException If no matching constructor is found for the provided arguments.
+   */
+  private def loadFunctionLibraryFactories(): (Map[String, IFhirPathFunctionLibraryFactory], Seq[String]) = {
+    val factoriesBuilder = Map.newBuilder[String, IFhirPathFunctionLibraryFactory]
+    val packageNamesBuilder = Seq.newBuilder[String]
+
+    // Iterate over configuration keys
+    librariesConfig.root().keySet().forEach { key =>
+      val libraryConfig = librariesConfig.getConfig(key)
+
+      // Dynamically load the class
+      val className = libraryConfig.getString("className")
+      val clazz = Class.forName(className)
+
+      // Add the package name to the list
+      packageNamesBuilder += clazz.getPackageName
+
+      // Check if arguments (args) are provided
+      val instance = if (libraryConfig.hasPath("args")) {
+        val args = libraryConfig.getAnyRefList("args").toArray
+        val constructors = clazz.getConstructors
+
+        // Find a matching constructor and pass the arguments
+        val constructor = constructors.find(_.getParameterCount == args.length)
+          .getOrElse(throw new IllegalArgumentException(s"No matching constructor found for $className with args: ${args.mkString(",")}"))
+
+        constructor.newInstance(args: _*).asInstanceOf[IFhirPathFunctionLibraryFactory]
+      } else {
+        // Default no-arg constructor
+        clazz.getDeclaredConstructor().newInstance().asInstanceOf[IFhirPathFunctionLibraryFactory]
+      }
+
+      factoriesBuilder += key -> instance
+    }
+
+    // Return both the map and the package names
+    (factoriesBuilder.result(), packageNamesBuilder.result())
+  }
+}

--- a/tofhir-engine/src/main/scala/io/tofhir/engine/config/ToFhirEngineConfig.scala
+++ b/tofhir-engine/src/main/scala/io/tofhir/engine/config/ToFhirEngineConfig.scala
@@ -60,4 +60,6 @@ class ToFhirEngineConfig(toFhirEngineConfig: Config) {
 
   /** Period (in milliseconds) to run archiving task for file streaming jobs */
   lazy val streamArchivingFrequency: Int = Try(toFhirEngineConfig.getInt("archiving.stream-archiving-frequency")).toOption.getOrElse(5000)
+  /** Configuration of external function libraries */
+  lazy val functionLibrariesConfig: Option[FunctionLibrariesConfig] = Try(new FunctionLibrariesConfig(toFhirEngineConfig.getConfig("functionLibraries"))).toOption
 }

--- a/tofhir-server/src/main/resources/application.conf
+++ b/tofhir-server/src/main/resources/application.conf
@@ -71,6 +71,17 @@ tofhir {
 
   # Database folder of toFHIR (e.g., to maintain synchronization times for scheduled jobs)
   db-path = "tofhir-db"
+
+  # External function libraries containing function to be used within FHIRPath expressions
+  functionLibraries {
+    rxn {
+      className = "io.tofhir.rxnorm.RxNormApiFunctionLibraryFactory"
+      args = ["https://rxnav.nlm.nih.gov", 2]
+    }
+    cst {
+      className = "io.tofhir.common.util.CustomMappingFunctionsFactory"
+    }
+  }
 }
 
 fhir = {

--- a/tofhir-server/src/main/scala/io/tofhir/server/endpoint/ToFhirServerEndpoint.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/endpoint/ToFhirServerEndpoint.scala
@@ -50,7 +50,14 @@ class ToFhirServerEndpoint(toFhirEngineConfig: ToFhirEngineConfig, webServerConf
   )
 
   val fhirDefinitionsEndpoint = new FhirDefinitionsEndpoint(fhirDefinitionsConfig)
-  val fhirPathFunctionsEndpoint = new FhirPathFunctionsEndpoint(Seq("io.onfhir.path", "io.tofhir.engine.mapping"))
+
+  val functionLibraryPackages: Seq[String] =
+    Seq("io.onfhir.path", "io.tofhir.engine.mapping") ++
+      toFhirEngineConfig.functionLibrariesConfig // add external function libraries
+        .map(_.libraryPackageNames)
+        .getOrElse(Seq.empty)
+  val fhirPathFunctionsEndpoint = new FhirPathFunctionsEndpoint(functionLibraryPackages)
+
   val redcapEndpoint =  redCapServiceConfig.map(config => new RedCapEndpoint(config))
   val fileSystemTreeStructureEndpoint = new FileSystemTreeStructureEndpoint()
   val metadataEndpoint = new MetadataEndpoint(toFhirEngineConfig, webServerConfig, fhirDefinitionsConfig, redCapServiceConfig)

--- a/tofhir-server/src/main/scala/io/tofhir/server/service/ExecutionService.scala
+++ b/tofhir-server/src/main/scala/io/tofhir/server/service/ExecutionService.scala
@@ -1,8 +1,6 @@
 package io.tofhir.server.service
 
 import com.typesafe.scalalogging.LazyLogging
-import io.onfhir.path.IFhirPathFunctionLibraryFactory
-import io.tofhir.common.util.CustomMappingFunctionsFactory
 import io.tofhir.engine.config.ToFhirConfig
 import io.tofhir.engine.env.EnvironmentVariableResolver
 import io.tofhir.engine.mapping.context.MappingContextLoader
@@ -12,7 +10,6 @@ import io.tofhir.engine.util.FhirMappingJobFormatter.formats
 import io.tofhir.engine.util.FileUtils
 import io.tofhir.engine.util.FileUtils.FileExtensions
 import io.tofhir.engine.{Execution, ToFhirEngine}
-import io.tofhir.rxnorm.RxNormApiFunctionLibraryFactory
 import io.tofhir.server.common.model.{BadRequest, ResourceNotFound}
 import io.tofhir.server.model.{ExecuteJobTask, TestResourceCreationRequest}
 import io.tofhir.server.repository.job.IJobRepository
@@ -39,12 +36,8 @@ import scala.concurrent.{ExecutionContext, ExecutionException, Future}
  */
 class ExecutionService(jobRepository: IJobRepository, mappingRepository: IMappingRepository, schemaRepository: ISchemaRepository) extends LazyLogging {
 
-  val externalMappingFunctions: Map[String, IFhirPathFunctionLibraryFactory] = Map(
-    "rxn" -> new RxNormApiFunctionLibraryFactory("https://rxnav.nlm.nih.gov", 2),
-    "cst" -> new CustomMappingFunctionsFactory()
-  )
   // TODO do not define engine and client as a global variable inside the class. (Testing becomes impossible)
-  val toFhirEngine = new ToFhirEngine(Some(mappingRepository), Some(schemaRepository), externalMappingFunctions)
+  val toFhirEngine = new ToFhirEngine(Some(mappingRepository), Some(schemaRepository))
 
   import Execution.actorSystem
 


### PR DESCRIPTION
Enhanced the application.conf file in the tofhir-engine to include the configuration for external function libraries. This update eliminates the need to explicitly pass these libraries to the ToFhirEngine class. 

Additionally, I fixed a bug where the documentation for these functions was not being returned through the API.